### PR TITLE
adding a custom command to throw an error if the use tries to build in debug mode in Visual Studio.

### DIFF
--- a/ides/error_if_debug_build.bat
+++ b/ides/error_if_debug_build.bat
@@ -1,0 +1,11 @@
+@echo off
+if %1==Debug (
+@echo on
+echo "===================================== OOPS ========================================"
+echo "this is just a friendly reminder from us."
+echo "you are trying to build Debug configuration. We don't support that unfortunately."
+echo "why don't you try building in the Release mode?"
+echo "==================================================================================="
+@echo off
+EXIT 1
+)

--- a/ides/error_if_debug_build.cmake
+++ b/ides/error_if_debug_build.cmake
@@ -1,0 +1,9 @@
+# include this file to throw an error if the user is trying to build a debug configuration.
+# must be included after the TARGET has been defined, for example a library or executable.
+
+if(MSVC)
+    add_custom_command(TARGET ${LIBRARY_NAME}
+                       PRE_BUILD
+                       COMMAND cmd /c ${CMAKE_CURRENT_LIST_DIR}/error_if_debug_build.bat "$(ConfigurationName)"
+                       COMMENT comment "throw an error if the user tries to build in debug configuration")
+endif()


### PR DESCRIPTION
As we don't support building our modules in debug mode in Visual Studio, let us warn the users when they do try to build in debug.