### PR TITLE
New cxx14 toolchains

### DIFF
--- a/flags/vs-cxx14.cmake
+++ b/flags/vs-cxx14.cmake
@@ -1,0 +1,19 @@
+# Copyright (c) 2013, 2018 Ruslan Baratov
+# All rights reserved.
+
+if(DEFINED POLLY_FLAGS_VS_CXX14_CMAKE_)
+  return()
+else()
+  set(POLLY_FLAGS_VS_CXX14_CMAKE_ 1)
+endif()
+
+include(polly_add_cache_flag)
+
+polly_add_cache_flag(CMAKE_CXX_FLAGS_INIT "/std:c++14")
+
+# Set CMAKE_CXX_STANDARD to cache to override project local value if present.
+# FORCE added in case CMAKE_CXX_STANDARD already set in cache
+# (e.g. set before 'project' by user).
+set(CMAKE_CXX_STANDARD 14 CACHE STRING "C++ Standard (toolchain)" FORCE)
+set(CMAKE_CXX_STANDARD_REQUIRED YES CACHE BOOL "C++ Standard required" FORCE)
+set(CMAKE_CXX_EXTENSIONS NO CACHE BOOL "C++ Standard extensions" FORCE)

--- a/gcc-cxx14-pic.cmake
+++ b/gcc-cxx14-pic.cmake
@@ -1,0 +1,25 @@
+# Copyright (c) 2016-2017, Ruslan Baratov
+# Copyright (c) 2017, David Hirvonen
+# All rights reserved.
+
+# based on original gcc-7-cxx14-pic.cmake but assumes gcc itself is gcc v7
+
+if(DEFINED POLLY_GCC_CXX14_PIC_CMAKE_)
+  return()
+else()
+  set(POLLY_GCC_CXX14_PIC_CMAKE_ 1)
+endif()
+
+include("${CMAKE_CURRENT_LIST_DIR}/utilities/polly_init.cmake")
+
+polly_init(
+    "gcc / c++14 support / PIC"
+    "Unix Makefiles"
+)
+
+include("${CMAKE_CURRENT_LIST_DIR}/utilities/polly_common.cmake")
+
+include("${CMAKE_CURRENT_LIST_DIR}/compiler/gcc.cmake")
+include("${CMAKE_CURRENT_LIST_DIR}/flags/cxx14.cmake")
+include("${CMAKE_CURRENT_LIST_DIR}/flags/cxx11-abi-disable.cmake") # effectively forced to 0 on RH7 and centos7, so disable to be consistent
+include("${CMAKE_CURRENT_LIST_DIR}/flags/fpic.cmake")

--- a/vs-15-2017-win64-cxx14.cmake
+++ b/vs-15-2017-win64-cxx14.cmake
@@ -1,0 +1,18 @@
+# Copyright (c) 2015-2017, Ruslan Baratov
+# All rights reserved.
+
+if(DEFINED POLLY_VS_15_2017_WIN64_CXX14_CMAKE_)
+  return()
+else()
+  set(POLLY_VS_15_2017_WIN64_CXX14_CMAKE_ 1)
+endif()
+
+include("${CMAKE_CURRENT_LIST_DIR}/utilities/polly_init.cmake")
+
+polly_init(
+    "Visual Studio 15 2017 Win64 / C++14"
+    "Visual Studio 15 2017 Win64"
+)
+
+include("${CMAKE_CURRENT_LIST_DIR}/utilities/polly_common.cmake")
+include("${CMAKE_CURRENT_LIST_DIR}/flags/vs-cxx14.cmake")


### PR DESCRIPTION
C++14 toolchain files for VS2017 and "gcc" (assuming gcc is gcc v7)