### PR TITLE
Add iOS13 support

### DIFF
--- a/ios-13-0-dep-9-3-armv7-arm64-bitcode.cmake
+++ b/ios-13-0-dep-9-3-armv7-arm64-bitcode.cmake
@@ -1,0 +1,44 @@
+# Copyright (c) 2017, Ruslan Baratov
+# All rights reserved.
+
+if(DEFINED POLLY_IOS_13_0_DEP_9_3_ARMV7_ARM64_BITCODE_CMAKE_)
+  return()
+else()
+  set(POLLY_IOS_13_0_DEP_9_3_ARMV7_ARM64_BITCODE_CMAKE_ 1)
+endif()
+
+include("${CMAKE_CURRENT_LIST_DIR}/utilities/polly_clear_environment_variables.cmake")
+
+include("${CMAKE_CURRENT_LIST_DIR}/utilities/polly_init.cmake")
+
+set(IOS_SDK_VERSION 13.0)
+set(IOS_DEPLOYMENT_SDK_VERSION 9.3)
+
+set(POLLY_XCODE_COMPILER "clang")
+polly_init(
+    "iOS ${IOS_SDK_VERSION} / Deployment ${IOS_DEPLOYMENT_SDK_VERSION} / Universal (armv7 arm64) / \
+${POLLY_XCODE_COMPILER} / \
+bitcode / \
+c++11 support"
+    "Xcode"
+)
+
+include("${CMAKE_CURRENT_LIST_DIR}/utilities/polly_common.cmake")
+
+include(polly_fatal_error)
+
+# Fix try_compile
+include(polly_ios_bundle_identifier)
+
+set(CMAKE_MACOSX_BUNDLE YES)
+set(CMAKE_XCODE_ATTRIBUTE_CODE_SIGN_IDENTITY "iPhone Developer")
+
+set(IPHONEOS_ARCHS armv7;arm64)
+set(IPHONESIMULATOR_ARCHS x86_64)
+
+include("${CMAKE_CURRENT_LIST_DIR}/compiler/xcode.cmake")
+include("${CMAKE_CURRENT_LIST_DIR}/os/iphone.cmake")
+include("${CMAKE_CURRENT_LIST_DIR}/flags/cxx14.cmake")
+include("${CMAKE_CURRENT_LIST_DIR}/flags/bitcode.cmake") # after os/iphone.cmake
+
+include("${CMAKE_CURRENT_LIST_DIR}/utilities/polly_ios_development_team.cmake")


### PR DESCRIPTION
Add toolchain file for using the iOS13 SDK that comes with Xcode13, base on the previous one added for iOS12*.