### PR TITLE
Add useful ndk based toolchains

### DIFF
--- a/ndk-arm64-v8a-21.cmake
+++ b/ndk-arm64-v8a-21.cmake
@@ -7,3 +7,4 @@ set(ANDROID_PLATFORM 21)
 
 include($ENV{ANDROID_NDK}/build/cmake/android.toolchain.cmake)
 
+set(CMAKE_CXX_STANDARD 14) # Override the default

--- a/ndk-arm64-v8a-21.cmake
+++ b/ndk-arm64-v8a-21.cmake
@@ -1,0 +1,9 @@
+
+# Set NEON - in theory redundant but to be clear
+set(ANDROID_ABI arm64-v8a)
+set(ANDROID_ARM_NEON TRUE)
+
+set(ANDROID_PLATFORM 21)
+
+include($ENV{ANDROID_NDK}/build/cmake/android.toolchain.cmake)
+

--- a/ndk-arm64-v8a-21.cmake
+++ b/ndk-arm64-v8a-21.cmake
@@ -1,10 +1,15 @@
 
+string(COMPARE EQUAL "$ENV{NDK_ROOT}" "" __empty_ndk_root_env)
+if(__empty_ndk_root_env)
+  message(FATAL_ERROR "No NDK_ROOT supplied")
+endif()
+
 # Set NEON - in theory redundant but to be clear
 set(ANDROID_ABI arm64-v8a)
 set(ANDROID_ARM_NEON TRUE)
 
 set(ANDROID_PLATFORM 21)
 
-include($ENV{ANDROID_NDK}/build/cmake/android.toolchain.cmake)
+include($ENV{NDK_ROOT}/build/cmake/android.toolchain.cmake)
 
 set(CMAKE_CXX_STANDARD 14) # Override the default

--- a/ndk-armeabi-v7a-19.cmake
+++ b/ndk-armeabi-v7a-19.cmake
@@ -1,11 +1,16 @@
 
+string(COMPARE EQUAL "$ENV{NDK_ROOT}" "" __empty_ndk_root_env)
+if(__empty_ndk_root_env)
+  message(FATAL_ERROR "No NDK_ROOT supplied")
+endif()
+
 # Assume neon
 set(ANDROID_ABI armeabi-v7a)
 set(ANDROID_ARM_NEON TRUE)
 
 set(ANDROID_PLATFORM 19)
 
-include($ENV{ANDROID_NDK}/build/cmake/android.toolchain.cmake)
+include($ENV{NDK_ROOT}/build/cmake/android.toolchain.cmake)
 
 set(CMAKE_CXX_STANDARD 14) # Override the default
 

--- a/ndk-armeabi-v7a-19.cmake
+++ b/ndk-armeabi-v7a-19.cmake
@@ -7,3 +7,5 @@ set(ANDROID_PLATFORM 19)
 
 include($ENV{ANDROID_NDK}/build/cmake/android.toolchain.cmake)
 
+set(CMAKE_CXX_STANDARD 14) # Override the default
+

--- a/ndk-armeabi-v7a-19.cmake
+++ b/ndk-armeabi-v7a-19.cmake
@@ -1,0 +1,9 @@
+
+# Assume neon
+set(ANDROID_ABI armeabi-v7a)
+set(ANDROID_ARM_NEON TRUE)
+
+set(ANDROID_PLATFORM 19)
+
+include($ENV{ANDROID_NDK}/build/cmake/android.toolchain.cmake)
+

--- a/ndk-armeabi-v7a-21.cmake
+++ b/ndk-armeabi-v7a-21.cmake
@@ -1,0 +1,16 @@
+
+string(COMPARE EQUAL "$ENV{NDK_ROOT}" "" __empty_ndk_root_env)
+if(__empty_ndk_root_env)
+  message(FATAL_ERROR "No NDK_ROOT supplied")
+endif()
+
+# Assume neon
+set(ANDROID_ABI armeabi-v7a)
+set(ANDROID_ARM_NEON TRUE)
+
+set(ANDROID_PLATFORM 21)
+
+include($ENV{NDK_ROOT}/build/cmake/android.toolchain.cmake)
+
+set(CMAKE_CXX_STANDARD 14) # Override the default
+

--- a/ndk-x86-19.cmake
+++ b/ndk-x86-19.cmake
@@ -5,3 +5,5 @@ set(ANDROID_PLATFORM 19)
 
 include($ENV{ANDROID_NDK}/build/cmake/android.toolchain.cmake)
 
+set(CMAKE_CXX_STANDARD 14) # Override the default
+

--- a/ndk-x86-19.cmake
+++ b/ndk-x86-19.cmake
@@ -1,9 +1,14 @@
 
+string(COMPARE EQUAL "$ENV{NDK_ROOT}" "" __empty_ndk_root_env)
+if(__empty_ndk_root_env)
+  message(FATAL_ERROR "No NDK_ROOT supplied")
+endif()
+
 set(ANDROID_ABI x86)
 
 set(ANDROID_PLATFORM 19)
 
-include($ENV{ANDROID_NDK}/build/cmake/android.toolchain.cmake)
+include($ENV{NDK_ROOT}/build/cmake/android.toolchain.cmake)
 
 set(CMAKE_CXX_STANDARD 14) # Override the default
 

--- a/ndk-x86-19.cmake
+++ b/ndk-x86-19.cmake
@@ -1,0 +1,7 @@
+
+set(ANDROID_ABI x86)
+
+set(ANDROID_PLATFORM 19)
+
+include($ENV{ANDROID_NDK}/build/cmake/android.toolchain.cmake)
+

--- a/ndk-x86-21.cmake
+++ b/ndk-x86-21.cmake
@@ -1,0 +1,14 @@
+
+string(COMPARE EQUAL "$ENV{NDK_ROOT}" "" __empty_ndk_root_env)
+if(__empty_ndk_root_env)
+  message(FATAL_ERROR "No NDK_ROOT supplied")
+endif()
+
+set(ANDROID_ABI x86)
+
+set(ANDROID_PLATFORM 21)
+
+include($ENV{NDK_ROOT}/build/cmake/android.toolchain.cmake)
+
+set(CMAKE_CXX_STANDARD 14) # Override the default
+

--- a/ndk-x86_64-21.cmake
+++ b/ndk-x86_64-21.cmake
@@ -1,0 +1,7 @@
+
+set(ANDROID_ABI x86_64)
+
+set(ANDROID_PLATFORM 21)
+
+include($ENV{ANDROID_NDK}/build/cmake/android.toolchain.cmake)
+

--- a/ndk-x86_64-21.cmake
+++ b/ndk-x86_64-21.cmake
@@ -5,3 +5,5 @@ set(ANDROID_PLATFORM 21)
 
 include($ENV{ANDROID_NDK}/build/cmake/android.toolchain.cmake)
 
+set(CMAKE_CXX_STANDARD 14) # Override the default
+

--- a/ndk-x86_64-21.cmake
+++ b/ndk-x86_64-21.cmake
@@ -1,9 +1,14 @@
 
+string(COMPARE EQUAL "$ENV{NDK_ROOT}" "" __empty_ndk_root_env)
+if(__empty_ndk_root_env)
+  message(FATAL_ERROR "No NDK_ROOT supplied")
+endif()
+
 set(ANDROID_ABI x86_64)
 
 set(ANDROID_PLATFORM 21)
 
-include($ENV{ANDROID_NDK}/build/cmake/android.toolchain.cmake)
+include($ENV{NDK_ROOT}/build/cmake/android.toolchain.cmake)
 
 set(CMAKE_CXX_STANDARD 14) # Override the default
 


### PR DESCRIPTION
Add android toolchains that do little more than set appropriate platform flags and include the
main NDK toolchain. Works differently to the pre-existing polly toolchains but designed to
support Android via the NDK toolchain - the old approach via cmake is being phased out.
Adding here for convenience.
