### PR TITLE
IDES2-3920 Add clang ninja toolchain

### DIFF
--- a/clang-cxx14-pic-hide-ninja.cmake
+++ b/clang-cxx14-pic-hide-ninja.cmake
@@ -1,0 +1,23 @@
+# Copyright (c) 2016-2018, Ruslan Baratov
+# Copyright (c) 2017, David Hirvonen
+# All rights reserved.
+
+if(DEFINED POLLY_CLANG_CXX14_PIC_CMAKE_)
+  return()
+else()
+  set(POLLY_CLANG_CXX14_PIC_CMAKE_ 1)
+endif()
+
+include("${CMAKE_CURRENT_LIST_DIR}/utilities/polly_init.cmake")
+
+polly_init(
+    "clang / c++14 support / PIC"
+    "Ninja"
+)
+
+include("${CMAKE_CURRENT_LIST_DIR}/utilities/polly_common.cmake")
+
+include("${CMAKE_CURRENT_LIST_DIR}/compiler/clang.cmake")
+include("${CMAKE_CURRENT_LIST_DIR}/flags/hidden.cmake")
+include("${CMAKE_CURRENT_LIST_DIR}/flags/cxx14.cmake")
+include("${CMAKE_CURRENT_LIST_DIR}/flags/fpic.cmake")

--- a/clang-cxx14-pic-hide.cmake
+++ b/clang-cxx14-pic-hide.cmake
@@ -1,0 +1,23 @@
+# Copyright (c) 2016-2018, Ruslan Baratov
+# Copyright (c) 2017, David Hirvonen
+# All rights reserved.
+
+if(DEFINED POLLY_CLANG_CXX14_PIC_CMAKE_)
+  return()
+else()
+  set(POLLY_CLANG_CXX14_PIC_CMAKE_ 1)
+endif()
+
+include("${CMAKE_CURRENT_LIST_DIR}/utilities/polly_init.cmake")
+
+polly_init(
+    "clang / c++14 support / PIC"
+    "Unix Makefiles"
+)
+
+include("${CMAKE_CURRENT_LIST_DIR}/utilities/polly_common.cmake")
+
+include("${CMAKE_CURRENT_LIST_DIR}/compiler/clang.cmake")
+include("${CMAKE_CURRENT_LIST_DIR}/flags/hidden.cmake")
+include("${CMAKE_CURRENT_LIST_DIR}/flags/cxx14.cmake")
+include("${CMAKE_CURRENT_LIST_DIR}/flags/fpic.cmake")

--- a/clang-cxx14-pic-ninja.cmake
+++ b/clang-cxx14-pic-ninja.cmake
@@ -1,0 +1,22 @@
+# Copyright (c) 2016-2018, Ruslan Baratov
+# Copyright (c) 2017, David Hirvonen
+# All rights reserved.
+
+if(DEFINED POLLY_CLANG_CXX14_PIC_CMAKE_)
+  return()
+else()
+  set(POLLY_CLANG_CXX14_PIC_CMAKE_ 1)
+endif()
+
+include("${CMAKE_CURRENT_LIST_DIR}/utilities/polly_init.cmake")
+
+polly_init(
+    "clang / c++14 support / PIC"
+    "Ninja"
+)
+
+include("${CMAKE_CURRENT_LIST_DIR}/utilities/polly_common.cmake")
+
+include("${CMAKE_CURRENT_LIST_DIR}/compiler/clang.cmake")
+include("${CMAKE_CURRENT_LIST_DIR}/flags/cxx14.cmake")
+include("${CMAKE_CURRENT_LIST_DIR}/flags/fpic.cmake")


### PR DESCRIPTION
Add ninja version of the clang toolchain file we use. Additionally
add hidden versions - shadowing ones we already have for gcc.