### PR TITLE
Add iOS 14.1 toolchains

### DIFF
--- a/ios-13-0-dep-9-3-arm64-bitcode-hide.cmake
+++ b/ios-13-0-dep-9-3-arm64-bitcode-hide.cmake
@@ -1,10 +1,10 @@
 # Copyright (c) 2017, Ruslan Baratov
 # All rights reserved.
 
-if(DEFINED POLLY_IOS_13_0_DEP_9_3_ARM64_CXX17_BITCODE_CMAKE_)
+if(DEFINED POLLY_IOS_13_0_DEP_9_3_ARM64_BITCODE_CMAKE_)
   return()
 else()
-	set(POLLY_IOS_13_0_DEP_9_3_ARM64_CXX17_BITCODE_CMAKE_ 1)
+  set(POLLY_IOS_13_0_DEP_9_3_ARM64_BITCODE_CMAKE_ 1)
 endif()
 
 include("${CMAKE_CURRENT_LIST_DIR}/utilities/polly_clear_environment_variables.cmake")
@@ -19,7 +19,7 @@ polly_init(
     "iOS ${IOS_SDK_VERSION} / Deployment ${IOS_DEPLOYMENT_SDK_VERSION} / Universal (arm64) / \
 ${POLLY_XCODE_COMPILER} / \
 bitcode / \
-c++17 support"
+c++11 support"
     "Xcode"
 )
 
@@ -39,7 +39,7 @@ set(IPHONESIMULATOR_ARCHS x86_64)
 include("${CMAKE_CURRENT_LIST_DIR}/compiler/xcode.cmake")
 include("${CMAKE_CURRENT_LIST_DIR}/flags/hidden.cmake")
 include("${CMAKE_CURRENT_LIST_DIR}/os/iphone.cmake")
-include("${CMAKE_CURRENT_LIST_DIR}/flags/cxx17.cmake")
+include("${CMAKE_CURRENT_LIST_DIR}/flags/cxx14.cmake")
 include("${CMAKE_CURRENT_LIST_DIR}/flags/bitcode.cmake") # after os/iphone.cmake
-include("${CMAKE_CURRENT_LIST_DIR}/flags/fno-aligned-allocation.cmake") # aligned allocation needs iOS >= 11.0
+
 include("${CMAKE_CURRENT_LIST_DIR}/utilities/polly_ios_development_team.cmake")

--- a/ios-13-0-dep-9-3-arm64-cxx17-bitcode-hide.cmake
+++ b/ios-13-0-dep-9-3-arm64-cxx17-bitcode-hide.cmake
@@ -1,10 +1,10 @@
 # Copyright (c) 2017, Ruslan Baratov
 # All rights reserved.
 
-if(DEFINED POLLY_IOS_13_0_DEP_9_3_ARMV7_ARM64_CXX17_BITCODE_CMAKE_)
+if(DEFINED POLLY_IOS_13_0_DEP_9_3_ARM64_CXX17_BITCODE_CMAKE_)
   return()
 else()
-	set(POLLY_IOS_13_0_DEP_9_3_ARMV7_ARM64_CXX17_BITCODE_CMAKE_ 1)
+	set(POLLY_IOS_13_0_DEP_9_3_ARM64_CXX17_BITCODE_CMAKE_ 1)
 endif()
 
 include("${CMAKE_CURRENT_LIST_DIR}/utilities/polly_clear_environment_variables.cmake")
@@ -33,7 +33,7 @@ include(polly_ios_bundle_identifier)
 set(CMAKE_MACOSX_BUNDLE YES)
 set(CMAKE_XCODE_ATTRIBUTE_CODE_SIGN_IDENTITY "iPhone Developer")
 
-set(IPHONEOS_ARCHS armv7;arm64)
+set(IPHONEOS_ARCHS arm64)
 set(IPHONESIMULATOR_ARCHS x86_64)
 
 include("${CMAKE_CURRENT_LIST_DIR}/compiler/xcode.cmake")

--- a/ios-14-1-dep-9-3-arm64-bitcode-hide.cmake
+++ b/ios-14-1-dep-9-3-arm64-bitcode-hide.cmake
@@ -1,0 +1,47 @@
+# Copyright (c) 2017, Ruslan Baratov
+# All rights reserved.
+
+if(DEFINED POLLY_IOS_14_1_DEP_9_3_ARM64_BITCODE_CMAKE_)
+  return()
+else()
+  set(POLLY_IOS_14_1_DEP_9_3_ARM64_BITCODE_CMAKE_ 1)
+endif()
+
+include("${CMAKE_CURRENT_LIST_DIR}/utilities/polly_clear_environment_variables.cmake")
+
+include("${CMAKE_CURRENT_LIST_DIR}/utilities/polly_init.cmake")
+
+set(IOS_SDK_VERSION 14.1)
+set(IOS_DEPLOYMENT_SDK_VERSION 9.3)
+
+set(POLLY_XCODE_COMPILER "clang")
+polly_init(
+    "iOS ${IOS_SDK_VERSION} / Deployment ${IOS_DEPLOYMENT_SDK_VERSION} / Universal (arm64) / \
+${POLLY_XCODE_COMPILER} / \
+bitcode / \
+c++11 support"
+    "Xcode"
+)
+
+include("${CMAKE_CURRENT_LIST_DIR}/utilities/polly_common.cmake")
+
+include(polly_fatal_error)
+
+# Fix try_compile
+include(polly_ios_bundle_identifier)
+
+set(CMAKE_MACOSX_BUNDLE YES)
+set(CMAKE_XCODE_ATTRIBUTE_CODE_SIGN_IDENTITY "iPhone Developer")
+
+set(IPHONEOS_ARCHS arm64)
+set(IPHONESIMULATOR_ARCHS x86_64)
+
+set(CMAKE_GENERATOR_TOOLSET buildsystem=1) # force "old xcode build system"
+
+include("${CMAKE_CURRENT_LIST_DIR}/compiler/xcode.cmake")
+include("${CMAKE_CURRENT_LIST_DIR}/flags/hidden.cmake")
+include("${CMAKE_CURRENT_LIST_DIR}/os/iphone.cmake")
+include("${CMAKE_CURRENT_LIST_DIR}/flags/cxx14.cmake")
+include("${CMAKE_CURRENT_LIST_DIR}/flags/bitcode.cmake") # after os/iphone.cmake
+
+include("${CMAKE_CURRENT_LIST_DIR}/utilities/polly_ios_development_team.cmake")

--- a/ios-14-1-dep-9-3-arm64-cxx17-bitcode-hide.cmake
+++ b/ios-14-1-dep-9-3-arm64-cxx17-bitcode-hide.cmake
@@ -1,10 +1,10 @@
 # Copyright (c) 2017, Ruslan Baratov
 # All rights reserved.
 
-if(DEFINED POLLY_IOS_14_1_DEP_9_3_ARMV7_ARM64_CXX17_BITCODE_CMAKE_)
+if(DEFINED POLLY_IOS_14_1_DEP_9_3_ARM64_CXX17_BITCODE_CMAKE_)
   return()
 else()
-	set(POLLY_IOS_14_1_DEP_9_3_ARMV7_ARM64_CXX17_BITCODE_CMAKE_ 1)
+	set(POLLY_IOS_14_1_DEP_9_3_ARM64_CXX17_BITCODE_CMAKE_ 1)
 endif()
 
 include("${CMAKE_CURRENT_LIST_DIR}/utilities/polly_clear_environment_variables.cmake")

--- a/ios-14-1-dep-9-3-arm64-cxx17-bitcode-hide.cmake
+++ b/ios-14-1-dep-9-3-arm64-cxx17-bitcode-hide.cmake
@@ -16,7 +16,7 @@ set(IOS_DEPLOYMENT_SDK_VERSION 9.3)
 
 set(POLLY_XCODE_COMPILER "clang")
 polly_init(
-    "iOS ${IOS_SDK_VERSION} / Deployment ${IOS_DEPLOYMENT_SDK_VERSION} / Universal (armv7 arm64) / \
+    "iOS ${IOS_SDK_VERSION} / Deployment ${IOS_DEPLOYMENT_SDK_VERSION} / Universal (arm64) / \
 ${POLLY_XCODE_COMPILER} / \
 bitcode / \
 c++17 support"
@@ -33,8 +33,10 @@ include(polly_ios_bundle_identifier)
 set(CMAKE_MACOSX_BUNDLE YES)
 set(CMAKE_XCODE_ATTRIBUTE_CODE_SIGN_IDENTITY "iPhone Developer")
 
-set(IPHONEOS_ARCHS armv7;arm64)
+set(IPHONEOS_ARCHS arm64)
 set(IPHONESIMULATOR_ARCHS x86_64)
+
+set(CMAKE_GENERATOR_TOOLSET buildsystem=1) # force "old xcode build system"
 
 include("${CMAKE_CURRENT_LIST_DIR}/compiler/xcode.cmake")
 include("${CMAKE_CURRENT_LIST_DIR}/flags/hidden.cmake")

--- a/ios-14-1-dep-9-3-armv7-arm64-bitcode-hide.cmake
+++ b/ios-14-1-dep-9-3-armv7-arm64-bitcode-hide.cmake
@@ -1,0 +1,45 @@
+# Copyright (c) 2017, Ruslan Baratov
+# All rights reserved.
+
+if(DEFINED POLLY_IOS_14_1_DEP_9_3_ARMV7_ARM64_BITCODE_CMAKE_)
+  return()
+else()
+  set(POLLY_IOS_14_1_DEP_9_3_ARMV7_ARM64_BITCODE_CMAKE_ 1)
+endif()
+
+include("${CMAKE_CURRENT_LIST_DIR}/utilities/polly_clear_environment_variables.cmake")
+
+include("${CMAKE_CURRENT_LIST_DIR}/utilities/polly_init.cmake")
+
+set(IOS_SDK_VERSION 14.1)
+set(IOS_DEPLOYMENT_SDK_VERSION 9.3)
+
+set(POLLY_XCODE_COMPILER "clang")
+polly_init(
+    "iOS ${IOS_SDK_VERSION} / Deployment ${IOS_DEPLOYMENT_SDK_VERSION} / Universal (armv7 arm64) / \
+${POLLY_XCODE_COMPILER} / \
+bitcode / \
+c++11 support"
+    "Xcode"
+)
+
+include("${CMAKE_CURRENT_LIST_DIR}/utilities/polly_common.cmake")
+
+include(polly_fatal_error)
+
+# Fix try_compile
+include(polly_ios_bundle_identifier)
+
+set(CMAKE_MACOSX_BUNDLE YES)
+set(CMAKE_XCODE_ATTRIBUTE_CODE_SIGN_IDENTITY "iPhone Developer")
+
+set(IPHONEOS_ARCHS armv7;arm64)
+set(IPHONESIMULATOR_ARCHS x86_64)
+
+include("${CMAKE_CURRENT_LIST_DIR}/compiler/xcode.cmake")
+include("${CMAKE_CURRENT_LIST_DIR}/flags/hidden.cmake")
+include("${CMAKE_CURRENT_LIST_DIR}/os/iphone.cmake")
+include("${CMAKE_CURRENT_LIST_DIR}/flags/cxx14.cmake")
+include("${CMAKE_CURRENT_LIST_DIR}/flags/bitcode.cmake") # after os/iphone.cmake
+
+include("${CMAKE_CURRENT_LIST_DIR}/utilities/polly_ios_development_team.cmake")

--- a/ios-14-1-dep-9-3-armv7-arm64-bitcode-hide.cmake
+++ b/ios-14-1-dep-9-3-armv7-arm64-bitcode-hide.cmake
@@ -36,6 +36,8 @@ set(CMAKE_XCODE_ATTRIBUTE_CODE_SIGN_IDENTITY "iPhone Developer")
 set(IPHONEOS_ARCHS armv7;arm64)
 set(IPHONESIMULATOR_ARCHS x86_64)
 
+set(CMAKE_GENERATOR_TOOLSET buildsystem=1) # force "old xcode build system"
+
 include("${CMAKE_CURRENT_LIST_DIR}/compiler/xcode.cmake")
 include("${CMAKE_CURRENT_LIST_DIR}/flags/hidden.cmake")
 include("${CMAKE_CURRENT_LIST_DIR}/os/iphone.cmake")

--- a/ios-14-1-dep-9-3-armv7-arm64-cxx17-bitcode-hide.cmake
+++ b/ios-14-1-dep-9-3-armv7-arm64-cxx17-bitcode-hide.cmake
@@ -1,0 +1,45 @@
+# Copyright (c) 2017, Ruslan Baratov
+# All rights reserved.
+
+if(DEFINED POLLY_IOS_14_1_DEP_9_3_ARMV7_ARM64_CXX17_BITCODE_CMAKE_)
+  return()
+else()
+	set(POLLY_IOS_14_1_DEP_9_3_ARMV7_ARM64_CXX17_BITCODE_CMAKE_ 1)
+endif()
+
+include("${CMAKE_CURRENT_LIST_DIR}/utilities/polly_clear_environment_variables.cmake")
+
+include("${CMAKE_CURRENT_LIST_DIR}/utilities/polly_init.cmake")
+
+set(IOS_SDK_VERSION 14.1)
+set(IOS_DEPLOYMENT_SDK_VERSION 9.3)
+
+set(POLLY_XCODE_COMPILER "clang")
+polly_init(
+    "iOS ${IOS_SDK_VERSION} / Deployment ${IOS_DEPLOYMENT_SDK_VERSION} / Universal (armv7 arm64) / \
+${POLLY_XCODE_COMPILER} / \
+bitcode / \
+c++11 support"
+    "Xcode"
+)
+
+include("${CMAKE_CURRENT_LIST_DIR}/utilities/polly_common.cmake")
+
+include(polly_fatal_error)
+
+# Fix try_compile
+include(polly_ios_bundle_identifier)
+
+set(CMAKE_MACOSX_BUNDLE YES)
+set(CMAKE_XCODE_ATTRIBUTE_CODE_SIGN_IDENTITY "iPhone Developer")
+
+set(IPHONEOS_ARCHS armv7;arm64)
+set(IPHONESIMULATOR_ARCHS x86_64)
+
+include("${CMAKE_CURRENT_LIST_DIR}/compiler/xcode.cmake")
+include("${CMAKE_CURRENT_LIST_DIR}/flags/hidden.cmake")
+include("${CMAKE_CURRENT_LIST_DIR}/os/iphone.cmake")
+include("${CMAKE_CURRENT_LIST_DIR}/flags/cxx17.cmake")
+include("${CMAKE_CURRENT_LIST_DIR}/flags/bitcode.cmake") # after os/iphone.cmake
+include("${CMAKE_CURRENT_LIST_DIR}/flags/fno-aligned-allocation.cmake") # aligned allocation needs iOS >= 11.0
+include("${CMAKE_CURRENT_LIST_DIR}/utilities/polly_ios_development_team.cmake")

--- a/ios-14-1-dep-9-3-armv7-arm64-cxx17-bitcode-hide.cmake
+++ b/ios-14-1-dep-9-3-armv7-arm64-cxx17-bitcode-hide.cmake
@@ -36,6 +36,8 @@ set(CMAKE_XCODE_ATTRIBUTE_CODE_SIGN_IDENTITY "iPhone Developer")
 set(IPHONEOS_ARCHS armv7;arm64)
 set(IPHONESIMULATOR_ARCHS x86_64)
 
+set(CMAKE_GENERATOR_TOOLSET buildsystem=1) # force "old xcode build system"
+
 include("${CMAKE_CURRENT_LIST_DIR}/compiler/xcode.cmake")
 include("${CMAKE_CURRENT_LIST_DIR}/flags/hidden.cmake")
 include("${CMAKE_CURRENT_LIST_DIR}/os/iphone.cmake")


### PR DESCRIPTION
Add new toolchains to build with iOS14.1. Note use of old build system - the new
build system is now the default otherwise, but we are seeing clashing builds with it.
Also provide 64bit-only versions of existing and new toolchains, plus fix some info
strings.