### PR TITLE
AVX2/512 variants of Visual Studio toolchains

### DIFF
--- a/flags/vs-avx2.cmake
+++ b/flags/vs-avx2.cmake
@@ -1,0 +1,13 @@
+# Copyright (c) 2013, 2018 Ruslan Baratov
+# All rights reserved.
+
+if(DEFINED POLLY_FLAGS_VS_AVX2_CMAKE_)
+  return()
+else()
+  set(POLLY_FLAGS_VS_AVX2_CMAKE_ 1)
+endif()
+
+include(polly_add_cache_flag)
+
+polly_add_cache_flag(CMAKE_CXX_FLAGS_INIT "/arch:AVX2")
+polly_add_cache_flag(CMAKE_C_FLAGS_INIT "/arch:AVX2")

--- a/flags/vs-avx512.cmake
+++ b/flags/vs-avx512.cmake
@@ -1,0 +1,13 @@
+# Copyright (c) 2013, 2018 Ruslan Baratov
+# All rights reserved.
+
+if(DEFINED POLLY_FLAGS_VS_AVX512_CMAKE_)
+  return()
+else()
+  set(POLLY_FLAGS_VS_AVX512_CMAKE_ 1)
+endif()
+
+include(polly_add_cache_flag)
+
+polly_add_cache_flag(CMAKE_CXX_FLAGS_INIT "/arch:AVX512")
+polly_add_cache_flag(CMAKE_C_FLAGS_INIT "/arch:AVX512")

--- a/vs-15-2017-win64-avx2-cxx14.cmake
+++ b/vs-15-2017-win64-avx2-cxx14.cmake
@@ -1,0 +1,19 @@
+# Copyright (c) 2015-2017, Ruslan Baratov
+# All rights reserved.
+
+if(DEFINED POLLY_VS_15_2017_WIN64_AVX2_CXX14_CMAKE_)
+  return()
+else()
+  set(POLLY_VS_15_2017_WIN64_AVX2_CXX14_CMAKE_ 1)
+endif()
+
+include("${CMAKE_CURRENT_LIST_DIR}/utilities/polly_init.cmake")
+
+polly_init(
+    "Visual Studio 15 2017 Win64 / AVX2 / C++14"
+    "Visual Studio 15 2017 Win64"
+)
+
+include("${CMAKE_CURRENT_LIST_DIR}/utilities/polly_common.cmake")
+include("${CMAKE_CURRENT_LIST_DIR}/flags/vs-cxx14.cmake")
+include("${CMAKE_CURRENT_LIST_DIR}/flags/vs-avx2.cmake")

--- a/vs-15-2017-win64-avx2-cxx17.cmake
+++ b/vs-15-2017-win64-avx2-cxx17.cmake
@@ -1,0 +1,19 @@
+# Copyright (c) 2015-2017, Ruslan Baratov
+# All rights reserved.
+
+if(DEFINED POLLY_VS_15_2017_WIN64_AVX2_CXX17_CMAKE_)
+  return()
+else()
+  set(POLLY_VS_15_2017_WIN64_AVX2_CXX17_CMAKE_ 1)
+endif()
+
+include("${CMAKE_CURRENT_LIST_DIR}/utilities/polly_init.cmake")
+
+polly_init(
+    "Visual Studio 15 2017 Win64 / AVX2 / C++17"
+    "Visual Studio 15 2017 Win64"
+)
+
+include("${CMAKE_CURRENT_LIST_DIR}/utilities/polly_common.cmake")
+include("${CMAKE_CURRENT_LIST_DIR}/flags/vs-cxx17.cmake")
+include("${CMAKE_CURRENT_LIST_DIR}/flags/vs-avx2.cmake")

--- a/vs-15-2017-win64-avx512-cxx14.cmake
+++ b/vs-15-2017-win64-avx512-cxx14.cmake
@@ -1,0 +1,19 @@
+# Copyright (c) 2015-2017, Ruslan Baratov
+# All rights reserved.
+
+if(DEFINED POLLY_VS_15_2017_WIN64_AVX512_CXX14_CMAKE_)
+  return()
+else()
+  set(POLLY_VS_15_2017_WIN64_AVX512_CXX14_CMAKE_ 1)
+endif()
+
+include("${CMAKE_CURRENT_LIST_DIR}/utilities/polly_init.cmake")
+
+polly_init(
+    "Visual Studio 15 2017 Win64 / AVX512 / C++14"
+    "Visual Studio 15 2017 Win64"
+)
+
+include("${CMAKE_CURRENT_LIST_DIR}/utilities/polly_common.cmake")
+include("${CMAKE_CURRENT_LIST_DIR}/flags/vs-cxx14.cmake")
+include("${CMAKE_CURRENT_LIST_DIR}/flags/vs-avx512.cmake")

--- a/vs-15-2017-win64-avx512-cxx17.cmake
+++ b/vs-15-2017-win64-avx512-cxx17.cmake
@@ -1,0 +1,19 @@
+# Copyright (c) 2015-2017, Ruslan Baratov
+# All rights reserved.
+
+if(DEFINED POLLY_VS_15_2017_WIN64_AVX512_CXX17_CMAKE_)
+  return()
+else()
+  set(POLLY_VS_15_2017_WIN64_AVX512_CXX17_CMAKE_ 1)
+endif()
+
+include("${CMAKE_CURRENT_LIST_DIR}/utilities/polly_init.cmake")
+
+polly_init(
+    "Visual Studio 15 2017 Win64 / AVX512 / C++17"
+    "Visual Studio 15 2017 Win64"
+)
+
+include("${CMAKE_CURRENT_LIST_DIR}/utilities/polly_common.cmake")
+include("${CMAKE_CURRENT_LIST_DIR}/flags/vs-cxx17.cmake")
+include("${CMAKE_CURRENT_LIST_DIR}/flags/vs-avx512.cmake")


### PR DESCRIPTION
Add variants of common VS2017 toolchains that add AVX2 or AVX512
as an additional option.