### PR TITLE
ENT-4547 select gcc arch

### DIFF
--- a/flags/cxx11-abi-disable.cmake
+++ b/flags/cxx11-abi-disable.cmake
@@ -11,3 +11,6 @@ include(polly_add_cache_flag)
 
 polly_add_cache_flag(CMAKE_CXX_FLAGS "-D_GLIBCXX_USE_CXX11_ABI=0")
 polly_add_cache_flag(CMAKE_C_FLAGS "-D_GLIBCXX_USE_CXX11_ABI=0")
+
+# Make it clear what we are requesting
+list(APPEND HUNTER_TOOLCHAIN_UNDETECTABLE_ID "cxx11-abi-disable")

--- a/flags/fno-aligned-allocation.cmake
+++ b/flags/fno-aligned-allocation.cmake
@@ -22,3 +22,5 @@ else()
   polly_add_cache_flag(CMAKE_Fortran_FLAGS_INIT "-fno-aligned-allocation")
 endif()
 
+# Make it clear what we are requesting
+list(APPEND HUNTER_TOOLCHAIN_UNDETECTABLE_ID "no-aligned-allocation")

--- a/flags/native.cmake
+++ b/flags/native.cmake
@@ -1,0 +1,13 @@
+# Copyright (c) 2017, NeroBurner
+# All rights reserved.
+
+if(DEFINED POLLY_FLAGS_NATIVE_CMAKE_)
+  return()
+else()
+  set(POLLY_FLAGS_NATIVE_CMAKE_ 1)
+endif()
+
+include(polly_add_cache_flag)
+
+polly_add_cache_flag(CMAKE_CXX_FLAGS "-march=native")
+polly_add_cache_flag(CMAKE_C_FLAGS "-march=native")

--- a/flags/sandybridge.cmake
+++ b/flags/sandybridge.cmake
@@ -1,0 +1,13 @@
+# Copyright (c) 2017, NeroBurner
+# All rights reserved.
+
+if(DEFINED POLLY_FLAGS_X86_64_CMAKE_)
+  return()
+else()
+  set(POLLY_FLAGS_NEON_CMAKE_ 1)
+endif()
+
+include(polly_add_cache_flag)
+
+polly_add_cache_flag(CMAKE_CXX_FLAGS "-march=sandybridge")
+polly_add_cache_flag(CMAKE_C_FLAGS "-march=sandybridge")

--- a/flags/sandybridge.cmake
+++ b/flags/sandybridge.cmake
@@ -11,3 +11,6 @@ include(polly_add_cache_flag)
 
 polly_add_cache_flag(CMAKE_CXX_FLAGS "-march=sandybridge")
 polly_add_cache_flag(CMAKE_C_FLAGS "-march=sandybridge")
+
+# Make it clear what we are requesting
+list(APPEND HUNTER_TOOLCHAIN_UNDETECTABLE_ID "sandybridge")

--- a/flags/sandybridge.cmake
+++ b/flags/sandybridge.cmake
@@ -1,10 +1,10 @@
 # Copyright (c) 2017, NeroBurner
 # All rights reserved.
 
-if(DEFINED POLLY_FLAGS_X86_64_CMAKE_)
+if(DEFINED POLLY_FLAGS_SANDYBRIDGE_CMAKE_)
   return()
 else()
-  set(POLLY_FLAGS_NEON_CMAKE_ 1)
+  set(POLLY_FLAGS_SANDYBRIDGE_CMAKE_ 1)
 endif()
 
 include(polly_add_cache_flag)

--- a/flags/skylake.cmake
+++ b/flags/skylake.cmake
@@ -1,10 +1,10 @@
 # Copyright (c) 2017, NeroBurner
 # All rights reserved.
 
-if(DEFINED POLLY_FLAGS_X86_64_CMAKE_)
+if(DEFINED POLLY_FLAGS_SKYLAKE_CMAKE_)
   return()
 else()
-  set(POLLY_FLAGS_NEON_CMAKE_ 1)
+  set(POLLY_FLAGS_SKYLAKE_CMAKE_ 1)
 endif()
 
 include(polly_add_cache_flag)

--- a/flags/skylake.cmake
+++ b/flags/skylake.cmake
@@ -1,0 +1,13 @@
+# Copyright (c) 2017, NeroBurner
+# All rights reserved.
+
+if(DEFINED POLLY_FLAGS_X86_64_CMAKE_)
+  return()
+else()
+  set(POLLY_FLAGS_NEON_CMAKE_ 1)
+endif()
+
+include(polly_add_cache_flag)
+
+polly_add_cache_flag(CMAKE_CXX_FLAGS "-march=skylake")
+polly_add_cache_flag(CMAKE_C_FLAGS "-march=skylake")

--- a/flags/skylake.cmake
+++ b/flags/skylake.cmake
@@ -11,3 +11,6 @@ include(polly_add_cache_flag)
 
 polly_add_cache_flag(CMAKE_CXX_FLAGS "-march=skylake")
 polly_add_cache_flag(CMAKE_C_FLAGS "-march=skylake")
+
+# Make it clear what we are requesting
+list(APPEND HUNTER_TOOLCHAIN_UNDETECTABLE_ID "skylake")

--- a/flags/vs-avx2.cmake
+++ b/flags/vs-avx2.cmake
@@ -11,3 +11,6 @@ include(polly_add_cache_flag)
 
 polly_add_cache_flag(CMAKE_CXX_FLAGS_INIT "/arch:AVX2")
 polly_add_cache_flag(CMAKE_C_FLAGS_INIT "/arch:AVX2")
+
+# Make it clear what we are requesting
+list(APPEND HUNTER_TOOLCHAIN_UNDETECTABLE_ID "AVX2")

--- a/flags/vs-avx512.cmake
+++ b/flags/vs-avx512.cmake
@@ -11,3 +11,6 @@ include(polly_add_cache_flag)
 
 polly_add_cache_flag(CMAKE_CXX_FLAGS_INIT "/arch:AVX512")
 polly_add_cache_flag(CMAKE_C_FLAGS_INIT "/arch:AVX512")
+
+# Make it clear what we are requesting
+list(APPEND HUNTER_TOOLCHAIN_UNDETECTABLE_ID "AVX512")

--- a/flags/x86-64.cmake
+++ b/flags/x86-64.cmake
@@ -1,0 +1,13 @@
+# Copyright (c) 2017, NeroBurner
+# All rights reserved.
+
+if(DEFINED POLLY_FLAGS_X86_64_CMAKE_)
+  return()
+else()
+  set(POLLY_FLAGS_NEON_CMAKE_ 1)
+endif()
+
+include(polly_add_cache_flag)
+
+polly_add_cache_flag(CMAKE_CXX_FLAGS "-march=x86-64")
+polly_add_cache_flag(CMAKE_C_FLAGS "-march=x86-64")

--- a/flags/x86-64.cmake
+++ b/flags/x86-64.cmake
@@ -4,7 +4,7 @@
 if(DEFINED POLLY_FLAGS_X86_64_CMAKE_)
   return()
 else()
-  set(POLLY_FLAGS_NEON_CMAKE_ 1)
+  set(POLLY_FLAGS_X86_64_CMAKE_ 1)
 endif()
 
 include(polly_add_cache_flag)

--- a/flags/x86-64.cmake
+++ b/flags/x86-64.cmake
@@ -11,3 +11,6 @@ include(polly_add_cache_flag)
 
 polly_add_cache_flag(CMAKE_CXX_FLAGS "-march=x86-64")
 polly_add_cache_flag(CMAKE_C_FLAGS "-march=x86-64")
+
+# Make it clear what we are requesting
+list(APPEND HUNTER_TOOLCHAIN_UNDETECTABLE_ID "x86-64")

--- a/gcc-cxx14-generic-pic-hide-ninja.cmake
+++ b/gcc-cxx14-generic-pic-hide-ninja.cmake
@@ -4,16 +4,16 @@
 
 # based on original gcc-7-cxx14-pic.cmake but assumes gcc itself is gcc v7
 
-if(DEFINED POLLY_GCC_CXX14_PIC_CMAKE_)
+if(DEFINED POLLY_GCC_CXX14_GENERIC_PIC_HIDE_NINJA_CMAKE_)
   return()
 else()
-  set(POLLY_GCC_CXX14_PIC_CMAKE_ 1)
+  set(POLLY_GCC_CXX14_GENERIC_PIC_HIDE_NINJA_CMAKE_ 1)
 endif()
 
 include("${CMAKE_CURRENT_LIST_DIR}/utilities/polly_init.cmake")
 
 polly_init(
-    "gcc / c++14 support / Generic x64 / PIC"
+    "gcc / c++14 support / Generic x64 / PIC / hide"
     "Ninja"
 )
 
@@ -23,5 +23,5 @@ include("${CMAKE_CURRENT_LIST_DIR}/compiler/gcc.cmake")
 include("${CMAKE_CURRENT_LIST_DIR}/flags/hidden.cmake")
 include("${CMAKE_CURRENT_LIST_DIR}/flags/cxx14.cmake")
 include("${CMAKE_CURRENT_LIST_DIR}/flags/cxx11-abi-disable.cmake") # effectively forced to 0 on RH7 and centos7, so disable to be consistent
-include("${CMAKE_CURRENT_LIST_DIR}/flags/x86-64.cmake") # target generic procesor
+include("${CMAKE_CURRENT_LIST_DIR}/flags/x86-64.cmake") # target generic processor
 include("${CMAKE_CURRENT_LIST_DIR}/flags/fpic.cmake")

--- a/gcc-cxx14-generic-pic-hide-ninja.cmake
+++ b/gcc-cxx14-generic-pic-hide-ninja.cmake
@@ -4,16 +4,16 @@
 
 # based on original gcc-7-cxx14-pic.cmake but assumes gcc itself is gcc v7
 
-if(DEFINED POLLY_GCC_CXX17_PIC_CMAKE_)
+if(DEFINED POLLY_GCC_CXX14_PIC_CMAKE_)
   return()
 else()
-  set(POLLY_GCC_CXX17_PIC_CMAKE_ 1)
+  set(POLLY_GCC_CXX14_PIC_CMAKE_ 1)
 endif()
 
 include("${CMAKE_CURRENT_LIST_DIR}/utilities/polly_init.cmake")
 
 polly_init(
-    "gcc / c++17 support / Generic x64 / PIC"
+    "gcc / c++14 support / Generic x64 / PIC"
     "Ninja"
 )
 
@@ -21,7 +21,7 @@ include("${CMAKE_CURRENT_LIST_DIR}/utilities/polly_common.cmake")
 
 include("${CMAKE_CURRENT_LIST_DIR}/compiler/gcc.cmake")
 include("${CMAKE_CURRENT_LIST_DIR}/flags/hidden.cmake")
-include("${CMAKE_CURRENT_LIST_DIR}/flags/cxx17.cmake")
+include("${CMAKE_CURRENT_LIST_DIR}/flags/cxx14.cmake")
 include("${CMAKE_CURRENT_LIST_DIR}/flags/cxx11-abi-disable.cmake") # effectively forced to 0 on RH7 and centos7, so disable to be consistent
 include("${CMAKE_CURRENT_LIST_DIR}/flags/x86-64.cmake") # target generic procesor
 include("${CMAKE_CURRENT_LIST_DIR}/flags/fpic.cmake")

--- a/gcc-cxx14-generic-pic-ninja.cmake
+++ b/gcc-cxx14-generic-pic-ninja.cmake
@@ -4,10 +4,10 @@
 
 # based on original gcc-7-cxx14-pic.cmake but assumes gcc itself is gcc v7
 
-if(DEFINED POLLY_GCC_CXX14_PIC_CMAKE_)
+if(DEFINED POLLY_GCC_CXX14_GENERIC_PIC_NINJA_CMAKE_)
   return()
 else()
-  set(POLLY_GCC_CXX14_PIC_CMAKE_ 1)
+  set(POLLY_GCC_CXX14_GENERIC_PIC_NINJA_CMAKE_ 1)
 endif()
 
 include("${CMAKE_CURRENT_LIST_DIR}/utilities/polly_init.cmake")
@@ -22,5 +22,5 @@ include("${CMAKE_CURRENT_LIST_DIR}/utilities/polly_common.cmake")
 include("${CMAKE_CURRENT_LIST_DIR}/compiler/gcc.cmake")
 include("${CMAKE_CURRENT_LIST_DIR}/flags/cxx14.cmake")
 include("${CMAKE_CURRENT_LIST_DIR}/flags/cxx11-abi-disable.cmake") # effectively forced to 0 on RH7 and centos7, so disable to be consistent
-include("${CMAKE_CURRENT_LIST_DIR}/flags/x86-64.cmake") # target generic procesor
+include("${CMAKE_CURRENT_LIST_DIR}/flags/x86-64.cmake") # target generic processor
 include("${CMAKE_CURRENT_LIST_DIR}/flags/fpic.cmake")

--- a/gcc-cxx14-generic-pic-ninja.cmake
+++ b/gcc-cxx14-generic-pic-ninja.cmake
@@ -4,24 +4,23 @@
 
 # based on original gcc-7-cxx14-pic.cmake but assumes gcc itself is gcc v7
 
-if(DEFINED POLLY_GCC_CXX17_PIC_CMAKE_)
+if(DEFINED POLLY_GCC_CXX14_PIC_CMAKE_)
   return()
 else()
-  set(POLLY_GCC_CXX17_PIC_CMAKE_ 1)
+  set(POLLY_GCC_CXX14_PIC_CMAKE_ 1)
 endif()
 
 include("${CMAKE_CURRENT_LIST_DIR}/utilities/polly_init.cmake")
 
 polly_init(
-    "gcc / c++17 support / Generic x64 / PIC"
+    "gcc / c++14 support / Generic x64 / PIC"
     "Ninja"
 )
 
 include("${CMAKE_CURRENT_LIST_DIR}/utilities/polly_common.cmake")
 
 include("${CMAKE_CURRENT_LIST_DIR}/compiler/gcc.cmake")
-include("${CMAKE_CURRENT_LIST_DIR}/flags/hidden.cmake")
-include("${CMAKE_CURRENT_LIST_DIR}/flags/cxx17.cmake")
+include("${CMAKE_CURRENT_LIST_DIR}/flags/cxx14.cmake")
 include("${CMAKE_CURRENT_LIST_DIR}/flags/cxx11-abi-disable.cmake") # effectively forced to 0 on RH7 and centos7, so disable to be consistent
 include("${CMAKE_CURRENT_LIST_DIR}/flags/x86-64.cmake") # target generic procesor
 include("${CMAKE_CURRENT_LIST_DIR}/flags/fpic.cmake")

--- a/gcc-cxx14-native-pic-hide-ninja.cmake
+++ b/gcc-cxx14-native-pic-hide-ninja.cmake
@@ -1,0 +1,27 @@
+# Copyright (c) 2016-2017, Ruslan Baratov
+# Copyright (c) 2017, David Hirvonen
+# All rights reserved.
+
+# based on original gcc-7-cxx14-pic.cmake but assumes gcc itself is gcc v7
+
+if(DEFINED POLLY_GCC_CXX14_PIC_CMAKE_)
+  return()
+else()
+  set(POLLY_GCC_CXX14_PIC_CMAKE_ 1)
+endif()
+
+include("${CMAKE_CURRENT_LIST_DIR}/utilities/polly_init.cmake")
+
+polly_init(
+    "gcc / c++14 support / native / PIC"
+    "Ninja"
+)
+
+include("${CMAKE_CURRENT_LIST_DIR}/utilities/polly_common.cmake")
+
+include("${CMAKE_CURRENT_LIST_DIR}/compiler/gcc.cmake")
+include("${CMAKE_CURRENT_LIST_DIR}/flags/hidden.cmake")
+include("${CMAKE_CURRENT_LIST_DIR}/flags/cxx14.cmake")
+include("${CMAKE_CURRENT_LIST_DIR}/flags/cxx11-abi-disable.cmake") # effectively forced to 0 on RH7 and centos7, so disable to be consistent
+include("${CMAKE_CURRENT_LIST_DIR}/flags/native.cmake") # explicitly request native processor
+include("${CMAKE_CURRENT_LIST_DIR}/flags/fpic.cmake")

--- a/gcc-cxx14-sandybridge-pic-hide-ninja.cmake
+++ b/gcc-cxx14-sandybridge-pic-hide-ninja.cmake
@@ -4,16 +4,16 @@
 
 # based on original gcc-7-cxx14-pic.cmake but assumes gcc itself is gcc v7
 
-if(DEFINED POLLY_GCC_CXX17_PIC_CMAKE_)
+if(DEFINED POLLY_GCC_CXX14_PIC_CMAKE_)
   return()
 else()
-  set(POLLY_GCC_CXX17_PIC_CMAKE_ 1)
+  set(POLLY_GCC_CXX14_PIC_CMAKE_ 1)
 endif()
 
 include("${CMAKE_CURRENT_LIST_DIR}/utilities/polly_init.cmake")
 
 polly_init(
-    "gcc / c++17 support / Generic x64 / PIC"
+    "gcc / c++14 support / Sandybridge / PIC"
     "Ninja"
 )
 
@@ -21,7 +21,7 @@ include("${CMAKE_CURRENT_LIST_DIR}/utilities/polly_common.cmake")
 
 include("${CMAKE_CURRENT_LIST_DIR}/compiler/gcc.cmake")
 include("${CMAKE_CURRENT_LIST_DIR}/flags/hidden.cmake")
-include("${CMAKE_CURRENT_LIST_DIR}/flags/cxx17.cmake")
+include("${CMAKE_CURRENT_LIST_DIR}/flags/cxx14.cmake")
 include("${CMAKE_CURRENT_LIST_DIR}/flags/cxx11-abi-disable.cmake") # effectively forced to 0 on RH7 and centos7, so disable to be consistent
-include("${CMAKE_CURRENT_LIST_DIR}/flags/x86-64.cmake") # target generic procesor
+include("${CMAKE_CURRENT_LIST_DIR}/flags/sandybridge.cmake") # target generic procesor
 include("${CMAKE_CURRENT_LIST_DIR}/flags/fpic.cmake")

--- a/gcc-cxx14-sandybridge-pic-hide-ninja.cmake
+++ b/gcc-cxx14-sandybridge-pic-hide-ninja.cmake
@@ -23,5 +23,5 @@ include("${CMAKE_CURRENT_LIST_DIR}/compiler/gcc.cmake")
 include("${CMAKE_CURRENT_LIST_DIR}/flags/hidden.cmake")
 include("${CMAKE_CURRENT_LIST_DIR}/flags/cxx14.cmake")
 include("${CMAKE_CURRENT_LIST_DIR}/flags/cxx11-abi-disable.cmake") # effectively forced to 0 on RH7 and centos7, so disable to be consistent
-include("${CMAKE_CURRENT_LIST_DIR}/flags/sandybridge.cmake") # target generic procesor
+include("${CMAKE_CURRENT_LIST_DIR}/flags/sandybridge.cmake") # target explicit procesor
 include("${CMAKE_CURRENT_LIST_DIR}/flags/fpic.cmake")

--- a/gcc-cxx14-sandybridge-pic-hide-ninja.cmake
+++ b/gcc-cxx14-sandybridge-pic-hide-ninja.cmake
@@ -4,16 +4,16 @@
 
 # based on original gcc-7-cxx14-pic.cmake but assumes gcc itself is gcc v7
 
-if(DEFINED POLLY_GCC_CXX14_PIC_CMAKE_)
+if(DEFINED POLLY_GCC_CXX14_SANDYBRIDGE_PIC_HIDE_NINJA_CMAKE_)
   return()
 else()
-  set(POLLY_GCC_CXX14_PIC_CMAKE_ 1)
+  set(POLLY_GCC_CXX14_SANDYBRIDGE_PIC_HIDE_NINJA_CMAKE_ 1)
 endif()
 
 include("${CMAKE_CURRENT_LIST_DIR}/utilities/polly_init.cmake")
 
 polly_init(
-    "gcc / c++14 support / Sandybridge / PIC"
+    "gcc / c++14 support / Sandybridge / PIC / hide"
     "Ninja"
 )
 
@@ -23,5 +23,5 @@ include("${CMAKE_CURRENT_LIST_DIR}/compiler/gcc.cmake")
 include("${CMAKE_CURRENT_LIST_DIR}/flags/hidden.cmake")
 include("${CMAKE_CURRENT_LIST_DIR}/flags/cxx14.cmake")
 include("${CMAKE_CURRENT_LIST_DIR}/flags/cxx11-abi-disable.cmake") # effectively forced to 0 on RH7 and centos7, so disable to be consistent
-include("${CMAKE_CURRENT_LIST_DIR}/flags/sandybridge.cmake") # target explicit procesor
+include("${CMAKE_CURRENT_LIST_DIR}/flags/sandybridge.cmake") # target specific processor
 include("${CMAKE_CURRENT_LIST_DIR}/flags/fpic.cmake")

--- a/gcc-cxx14-sandybridge-pic-ninja.cmake
+++ b/gcc-cxx14-sandybridge-pic-ninja.cmake
@@ -4,10 +4,10 @@
 
 # based on original gcc-7-cxx14-pic.cmake but assumes gcc itself is gcc v7
 
-if(DEFINED POLLY_GCC_CXX14_PIC_CMAKE_)
+if(DEFINED POLLY_GCC_CXX14_SANDYBRIDGE_PIC_NINJA_CMAKE_)
   return()
 else()
-  set(POLLY_GCC_CXX14_PIC_CMAKE_ 1)
+  set(POLLY_GCC_CXX14_SANDYBRIDGE_PIC_NINJA_CMAKE_ 1)
 endif()
 
 include("${CMAKE_CURRENT_LIST_DIR}/utilities/polly_init.cmake")
@@ -22,5 +22,5 @@ include("${CMAKE_CURRENT_LIST_DIR}/utilities/polly_common.cmake")
 include("${CMAKE_CURRENT_LIST_DIR}/compiler/gcc.cmake")
 include("${CMAKE_CURRENT_LIST_DIR}/flags/cxx14.cmake")
 include("${CMAKE_CURRENT_LIST_DIR}/flags/cxx11-abi-disable.cmake") # effectively forced to 0 on RH7 and centos7, so disable to be consistent
-include("${CMAKE_CURRENT_LIST_DIR}/flags/sandybridge.cmake") # target explicit procesor
+include("${CMAKE_CURRENT_LIST_DIR}/flags/sandybridge.cmake") # target specific processor
 include("${CMAKE_CURRENT_LIST_DIR}/flags/fpic.cmake")

--- a/gcc-cxx14-sandybridge-pic-ninja.cmake
+++ b/gcc-cxx14-sandybridge-pic-ninja.cmake
@@ -22,5 +22,5 @@ include("${CMAKE_CURRENT_LIST_DIR}/utilities/polly_common.cmake")
 include("${CMAKE_CURRENT_LIST_DIR}/compiler/gcc.cmake")
 include("${CMAKE_CURRENT_LIST_DIR}/flags/cxx14.cmake")
 include("${CMAKE_CURRENT_LIST_DIR}/flags/cxx11-abi-disable.cmake") # effectively forced to 0 on RH7 and centos7, so disable to be consistent
-include("${CMAKE_CURRENT_LIST_DIR}/flags/sandybridge.cmake") # target generic procesor
+include("${CMAKE_CURRENT_LIST_DIR}/flags/sandybridge.cmake") # target explicit procesor
 include("${CMAKE_CURRENT_LIST_DIR}/flags/fpic.cmake")

--- a/gcc-cxx14-sandybridge-pic-ninja.cmake
+++ b/gcc-cxx14-sandybridge-pic-ninja.cmake
@@ -4,24 +4,23 @@
 
 # based on original gcc-7-cxx14-pic.cmake but assumes gcc itself is gcc v7
 
-if(DEFINED POLLY_GCC_CXX17_PIC_CMAKE_)
+if(DEFINED POLLY_GCC_CXX14_PIC_CMAKE_)
   return()
 else()
-  set(POLLY_GCC_CXX17_PIC_CMAKE_ 1)
+  set(POLLY_GCC_CXX14_PIC_CMAKE_ 1)
 endif()
 
 include("${CMAKE_CURRENT_LIST_DIR}/utilities/polly_init.cmake")
 
 polly_init(
-    "gcc / c++17 support / Generic x64 / PIC"
+    "gcc / c++14 support / Sandybridge / PIC"
     "Ninja"
 )
 
 include("${CMAKE_CURRENT_LIST_DIR}/utilities/polly_common.cmake")
 
 include("${CMAKE_CURRENT_LIST_DIR}/compiler/gcc.cmake")
-include("${CMAKE_CURRENT_LIST_DIR}/flags/hidden.cmake")
-include("${CMAKE_CURRENT_LIST_DIR}/flags/cxx17.cmake")
+include("${CMAKE_CURRENT_LIST_DIR}/flags/cxx14.cmake")
 include("${CMAKE_CURRENT_LIST_DIR}/flags/cxx11-abi-disable.cmake") # effectively forced to 0 on RH7 and centos7, so disable to be consistent
-include("${CMAKE_CURRENT_LIST_DIR}/flags/x86-64.cmake") # target generic procesor
+include("${CMAKE_CURRENT_LIST_DIR}/flags/sandybridge.cmake") # target generic procesor
 include("${CMAKE_CURRENT_LIST_DIR}/flags/fpic.cmake")

--- a/gcc-cxx14-skylake-pic-hide-ninja.cmake
+++ b/gcc-cxx14-skylake-pic-hide-ninja.cmake
@@ -4,16 +4,16 @@
 
 # based on original gcc-7-cxx14-pic.cmake but assumes gcc itself is gcc v7
 
-if(DEFINED POLLY_GCC_CXX17_PIC_CMAKE_)
+if(DEFINED POLLY_GCC_CXX14_PIC_CMAKE_)
   return()
 else()
-  set(POLLY_GCC_CXX17_PIC_CMAKE_ 1)
+  set(POLLY_GCC_CXX14_PIC_CMAKE_ 1)
 endif()
 
 include("${CMAKE_CURRENT_LIST_DIR}/utilities/polly_init.cmake")
 
 polly_init(
-    "gcc / c++17 support / Generic x64 / PIC"
+    "gcc / c++14 support / skylake / PIC"
     "Ninja"
 )
 
@@ -21,7 +21,7 @@ include("${CMAKE_CURRENT_LIST_DIR}/utilities/polly_common.cmake")
 
 include("${CMAKE_CURRENT_LIST_DIR}/compiler/gcc.cmake")
 include("${CMAKE_CURRENT_LIST_DIR}/flags/hidden.cmake")
-include("${CMAKE_CURRENT_LIST_DIR}/flags/cxx17.cmake")
+include("${CMAKE_CURRENT_LIST_DIR}/flags/cxx14.cmake")
 include("${CMAKE_CURRENT_LIST_DIR}/flags/cxx11-abi-disable.cmake") # effectively forced to 0 on RH7 and centos7, so disable to be consistent
-include("${CMAKE_CURRENT_LIST_DIR}/flags/x86-64.cmake") # target generic procesor
+include("${CMAKE_CURRENT_LIST_DIR}/flags/skylake.cmake") # target generic procesor
 include("${CMAKE_CURRENT_LIST_DIR}/flags/fpic.cmake")

--- a/gcc-cxx14-skylake-pic-hide-ninja.cmake
+++ b/gcc-cxx14-skylake-pic-hide-ninja.cmake
@@ -23,5 +23,5 @@ include("${CMAKE_CURRENT_LIST_DIR}/compiler/gcc.cmake")
 include("${CMAKE_CURRENT_LIST_DIR}/flags/hidden.cmake")
 include("${CMAKE_CURRENT_LIST_DIR}/flags/cxx14.cmake")
 include("${CMAKE_CURRENT_LIST_DIR}/flags/cxx11-abi-disable.cmake") # effectively forced to 0 on RH7 and centos7, so disable to be consistent
-include("${CMAKE_CURRENT_LIST_DIR}/flags/skylake.cmake") # target generic procesor
+include("${CMAKE_CURRENT_LIST_DIR}/flags/skylake.cmake") # target explicit procesor
 include("${CMAKE_CURRENT_LIST_DIR}/flags/fpic.cmake")

--- a/gcc-cxx14-skylake-pic-hide-ninja.cmake
+++ b/gcc-cxx14-skylake-pic-hide-ninja.cmake
@@ -4,16 +4,16 @@
 
 # based on original gcc-7-cxx14-pic.cmake but assumes gcc itself is gcc v7
 
-if(DEFINED POLLY_GCC_CXX14_PIC_CMAKE_)
+if(DEFINED POLLY_GCC_CXX14_SKYLAKE_PIC_HIDE_NINJA_CMAKE_)
   return()
 else()
-  set(POLLY_GCC_CXX14_PIC_CMAKE_ 1)
+  set(POLLY_GCC_CXX14_SKYLAKE_PIC_HIDE_NINJA_CMAKE_ 1)
 endif()
 
 include("${CMAKE_CURRENT_LIST_DIR}/utilities/polly_init.cmake")
 
 polly_init(
-    "gcc / c++14 support / skylake / PIC"
+    "gcc / c++14 support / skylake / PIC / hide"
     "Ninja"
 )
 
@@ -23,5 +23,5 @@ include("${CMAKE_CURRENT_LIST_DIR}/compiler/gcc.cmake")
 include("${CMAKE_CURRENT_LIST_DIR}/flags/hidden.cmake")
 include("${CMAKE_CURRENT_LIST_DIR}/flags/cxx14.cmake")
 include("${CMAKE_CURRENT_LIST_DIR}/flags/cxx11-abi-disable.cmake") # effectively forced to 0 on RH7 and centos7, so disable to be consistent
-include("${CMAKE_CURRENT_LIST_DIR}/flags/skylake.cmake") # target explicit procesor
+include("${CMAKE_CURRENT_LIST_DIR}/flags/skylake.cmake") # target specific processor
 include("${CMAKE_CURRENT_LIST_DIR}/flags/fpic.cmake")

--- a/gcc-cxx14-skylake-pic-ninja.cmake
+++ b/gcc-cxx14-skylake-pic-ninja.cmake
@@ -4,10 +4,10 @@
 
 # based on original gcc-7-cxx14-pic.cmake but assumes gcc itself is gcc v7
 
-if(DEFINED POLLY_GCC_CXX14_PIC_CMAKE_)
+if(DEFINED POLLY_GCC_CXX14_SKYLAKE_PIC_NINJA_CMAKE_)
   return()
 else()
-  set(POLLY_GCC_CXX14_PIC_CMAKE_ 1)
+  set(POLLY_GCC_CXX14_SKYLAKE_PIC_NINJA_CMAKE_ 1)
 endif()
 
 include("${CMAKE_CURRENT_LIST_DIR}/utilities/polly_init.cmake")
@@ -22,5 +22,5 @@ include("${CMAKE_CURRENT_LIST_DIR}/utilities/polly_common.cmake")
 include("${CMAKE_CURRENT_LIST_DIR}/compiler/gcc.cmake")
 include("${CMAKE_CURRENT_LIST_DIR}/flags/cxx14.cmake")
 include("${CMAKE_CURRENT_LIST_DIR}/flags/cxx11-abi-disable.cmake") # effectively forced to 0 on RH7 and centos7, so disable to be consistent
-include("${CMAKE_CURRENT_LIST_DIR}/flags/skylake.cmake") # target explicit procesor
+include("${CMAKE_CURRENT_LIST_DIR}/flags/skylake.cmake") # target specific processor
 include("${CMAKE_CURRENT_LIST_DIR}/flags/fpic.cmake")

--- a/gcc-cxx14-skylake-pic-ninja.cmake
+++ b/gcc-cxx14-skylake-pic-ninja.cmake
@@ -4,24 +4,23 @@
 
 # based on original gcc-7-cxx14-pic.cmake but assumes gcc itself is gcc v7
 
-if(DEFINED POLLY_GCC_CXX17_PIC_CMAKE_)
+if(DEFINED POLLY_GCC_CXX14_PIC_CMAKE_)
   return()
 else()
-  set(POLLY_GCC_CXX17_PIC_CMAKE_ 1)
+  set(POLLY_GCC_CXX14_PIC_CMAKE_ 1)
 endif()
 
 include("${CMAKE_CURRENT_LIST_DIR}/utilities/polly_init.cmake")
 
 polly_init(
-    "gcc / c++17 support / Generic x64 / PIC"
+    "gcc / c++14 support / skylake / PIC"
     "Ninja"
 )
 
 include("${CMAKE_CURRENT_LIST_DIR}/utilities/polly_common.cmake")
 
 include("${CMAKE_CURRENT_LIST_DIR}/compiler/gcc.cmake")
-include("${CMAKE_CURRENT_LIST_DIR}/flags/hidden.cmake")
-include("${CMAKE_CURRENT_LIST_DIR}/flags/cxx17.cmake")
+include("${CMAKE_CURRENT_LIST_DIR}/flags/cxx14.cmake")
 include("${CMAKE_CURRENT_LIST_DIR}/flags/cxx11-abi-disable.cmake") # effectively forced to 0 on RH7 and centos7, so disable to be consistent
-include("${CMAKE_CURRENT_LIST_DIR}/flags/x86-64.cmake") # target generic procesor
+include("${CMAKE_CURRENT_LIST_DIR}/flags/skylake.cmake") # target generic procesor
 include("${CMAKE_CURRENT_LIST_DIR}/flags/fpic.cmake")

--- a/gcc-cxx14-skylake-pic-ninja.cmake
+++ b/gcc-cxx14-skylake-pic-ninja.cmake
@@ -22,5 +22,5 @@ include("${CMAKE_CURRENT_LIST_DIR}/utilities/polly_common.cmake")
 include("${CMAKE_CURRENT_LIST_DIR}/compiler/gcc.cmake")
 include("${CMAKE_CURRENT_LIST_DIR}/flags/cxx14.cmake")
 include("${CMAKE_CURRENT_LIST_DIR}/flags/cxx11-abi-disable.cmake") # effectively forced to 0 on RH7 and centos7, so disable to be consistent
-include("${CMAKE_CURRENT_LIST_DIR}/flags/skylake.cmake") # target generic procesor
+include("${CMAKE_CURRENT_LIST_DIR}/flags/skylake.cmake") # target explicit procesor
 include("${CMAKE_CURRENT_LIST_DIR}/flags/fpic.cmake")

--- a/gcc-cxx17-generic-pic-hide-ninja.cmake
+++ b/gcc-cxx17-generic-pic-hide-ninja.cmake
@@ -1,0 +1,27 @@
+# Copyright (c) 2016-2017, Ruslan Baratov
+# Copyright (c) 2017, David Hirvonen
+# All rights reserved.
+
+# based on original gcc-7-cxx14-pic.cmake but assumes gcc itself is gcc v7
+
+if(DEFINED POLLY_GCC_CXX17_PIC_CMAKE_)
+  return()
+else()
+  set(POLLY_GCC_CXX17_PIC_CMAKE_ 1)
+endif()
+
+include("${CMAKE_CURRENT_LIST_DIR}/utilities/polly_init.cmake")
+
+polly_init(
+    "gcc / c++17 support / Gerneric x64 / PIC"
+    "Ninja"
+)
+
+include("${CMAKE_CURRENT_LIST_DIR}/utilities/polly_common.cmake")
+
+include("${CMAKE_CURRENT_LIST_DIR}/compiler/gcc.cmake")
+include("${CMAKE_CURRENT_LIST_DIR}/flags/hidden.cmake")
+include("${CMAKE_CURRENT_LIST_DIR}/flags/cxx17.cmake")
+include("${CMAKE_CURRENT_LIST_DIR}/flags/cxx11-abi-disable.cmake") # effectively forced to 0 on RH7 and centos7, so disable to be consistent
+include("${CMAKE_CURRENT_LIST_DIR}/flags/x86-64.cmake") # target generic procesor
+include("${CMAKE_CURRENT_LIST_DIR}/flags/fpic.cmake")

--- a/gcc-cxx17-generic-pic-hide-ninja.cmake
+++ b/gcc-cxx17-generic-pic-hide-ninja.cmake
@@ -4,16 +4,16 @@
 
 # based on original gcc-7-cxx14-pic.cmake but assumes gcc itself is gcc v7
 
-if(DEFINED POLLY_GCC_CXX17_PIC_CMAKE_)
+if(DEFINED POLLY_GCC_CXX17_GENERIC_PIC_HIDE_NINJA_CMAKE_)
   return()
 else()
-  set(POLLY_GCC_CXX17_PIC_CMAKE_ 1)
+  set(POLLY_GCC_CXX17_GENERIC_PIC_HIDE_NINJA_CMAKE_ 1)
 endif()
 
 include("${CMAKE_CURRENT_LIST_DIR}/utilities/polly_init.cmake")
 
 polly_init(
-    "gcc / c++17 support / Generic x64 / PIC"
+    "gcc / c++17 support / Generic x64 / PIC / hide"
     "Ninja"
 )
 
@@ -23,5 +23,5 @@ include("${CMAKE_CURRENT_LIST_DIR}/compiler/gcc.cmake")
 include("${CMAKE_CURRENT_LIST_DIR}/flags/hidden.cmake")
 include("${CMAKE_CURRENT_LIST_DIR}/flags/cxx17.cmake")
 include("${CMAKE_CURRENT_LIST_DIR}/flags/cxx11-abi-disable.cmake") # effectively forced to 0 on RH7 and centos7, so disable to be consistent
-include("${CMAKE_CURRENT_LIST_DIR}/flags/x86-64.cmake") # target generic procesor
+include("${CMAKE_CURRENT_LIST_DIR}/flags/x86-64.cmake") # target generic processor
 include("${CMAKE_CURRENT_LIST_DIR}/flags/fpic.cmake")

--- a/gcc-cxx17-native-pic-hide-ninja.cmake
+++ b/gcc-cxx17-native-pic-hide-ninja.cmake
@@ -13,7 +13,7 @@ endif()
 include("${CMAKE_CURRENT_LIST_DIR}/utilities/polly_init.cmake")
 
 polly_init(
-	"gcc / c++17 support / Sandybridge / PIC"
+    "gcc / c++17 support / native / PIC"
     "Ninja"
 )
 
@@ -23,5 +23,5 @@ include("${CMAKE_CURRENT_LIST_DIR}/compiler/gcc.cmake")
 include("${CMAKE_CURRENT_LIST_DIR}/flags/hidden.cmake")
 include("${CMAKE_CURRENT_LIST_DIR}/flags/cxx17.cmake")
 include("${CMAKE_CURRENT_LIST_DIR}/flags/cxx11-abi-disable.cmake") # effectively forced to 0 on RH7 and centos7, so disable to be consistent
-include("${CMAKE_CURRENT_LIST_DIR}/flags/sandybridge.cmake") # target explicit procesor
+include("${CMAKE_CURRENT_LIST_DIR}/flags/native.cmake") # explicitly request native
 include("${CMAKE_CURRENT_LIST_DIR}/flags/fpic.cmake")

--- a/gcc-cxx17-sandybridge-pic-hide-ninja.cmake
+++ b/gcc-cxx17-sandybridge-pic-hide-ninja.cmake
@@ -4,16 +4,16 @@
 
 # based on original gcc-7-cxx14-pic.cmake but assumes gcc itself is gcc v7
 
-if(DEFINED POLLY_GCC_CXX17_PIC_CMAKE_)
+if(DEFINED POLLY_GCC_CXX17_SANDYBRIDGE_PIC_HIDE_NINJA_CMAKE_)
   return()
 else()
-  set(POLLY_GCC_CXX17_PIC_CMAKE_ 1)
+  set(POLLY_GCC_CXX17_SANDYBRIDGE_PIC_HIDE_NINJA_CMAKE_ 1)
 endif()
 
 include("${CMAKE_CURRENT_LIST_DIR}/utilities/polly_init.cmake")
 
 polly_init(
-	"gcc / c++17 support / Sandybridge / PIC"
+	"gcc / c++17 support / Sandybridge / PIC / hide"
     "Ninja"
 )
 
@@ -23,5 +23,5 @@ include("${CMAKE_CURRENT_LIST_DIR}/compiler/gcc.cmake")
 include("${CMAKE_CURRENT_LIST_DIR}/flags/hidden.cmake")
 include("${CMAKE_CURRENT_LIST_DIR}/flags/cxx17.cmake")
 include("${CMAKE_CURRENT_LIST_DIR}/flags/cxx11-abi-disable.cmake") # effectively forced to 0 on RH7 and centos7, so disable to be consistent
-include("${CMAKE_CURRENT_LIST_DIR}/flags/sandybridge.cmake") # target explicit procesor
+include("${CMAKE_CURRENT_LIST_DIR}/flags/sandybridge.cmake") # target spoecific processor
 include("${CMAKE_CURRENT_LIST_DIR}/flags/fpic.cmake")

--- a/gcc-cxx17-sandybridge-pic-hide-ninja.cmake
+++ b/gcc-cxx17-sandybridge-pic-hide-ninja.cmake
@@ -1,0 +1,27 @@
+# Copyright (c) 2016-2017, Ruslan Baratov
+# Copyright (c) 2017, David Hirvonen
+# All rights reserved.
+
+# based on original gcc-7-cxx14-pic.cmake but assumes gcc itself is gcc v7
+
+if(DEFINED POLLY_GCC_CXX17_PIC_CMAKE_)
+  return()
+else()
+  set(POLLY_GCC_CXX17_PIC_CMAKE_ 1)
+endif()
+
+include("${CMAKE_CURRENT_LIST_DIR}/utilities/polly_init.cmake")
+
+polly_init(
+	"gcc / c++17 support / Sandybridge / PIC"
+    "Ninja"
+)
+
+include("${CMAKE_CURRENT_LIST_DIR}/utilities/polly_common.cmake")
+
+include("${CMAKE_CURRENT_LIST_DIR}/compiler/gcc.cmake")
+include("${CMAKE_CURRENT_LIST_DIR}/flags/hidden.cmake")
+include("${CMAKE_CURRENT_LIST_DIR}/flags/cxx17.cmake")
+include("${CMAKE_CURRENT_LIST_DIR}/flags/cxx11-abi-disable.cmake") # effectively forced to 0 on RH7 and centos7, so disable to be consistent
+include("${CMAKE_CURRENT_LIST_DIR}/flags/sandybridge.cmake") # target generic procesor
+include("${CMAKE_CURRENT_LIST_DIR}/flags/fpic.cmake")

--- a/gcc-cxx17-skylake-pic-hide-ninja.cmake
+++ b/gcc-cxx17-skylake-pic-hide-ninja.cmake
@@ -4,16 +4,16 @@
 
 # based on original gcc-7-cxx14-pic.cmake but assumes gcc itself is gcc v7
 
-if(DEFINED POLLY_GCC_CXX17_PIC_CMAKE_)
+if(DEFINED POLLY_GCC_CXX17_SKYLAKE_PIC_HIDE_NINJA_CMAKE_)
   return()
 else()
-  set(POLLY_GCC_CXX17_PIC_CMAKE_ 1)
+  set(POLLY_GCC_CXX17_SKYLAKE_PIC_HIDE_NINJA_CMAKE_ 1)
 endif()
 
 include("${CMAKE_CURRENT_LIST_DIR}/utilities/polly_init.cmake")
 
 polly_init(
-    "gcc / c++17 support / skylake / PIC"
+    "gcc / c++17 support / skylake / PIC / hide"
     "Ninja"
 )
 
@@ -23,5 +23,5 @@ include("${CMAKE_CURRENT_LIST_DIR}/compiler/gcc.cmake")
 include("${CMAKE_CURRENT_LIST_DIR}/flags/hidden.cmake")
 include("${CMAKE_CURRENT_LIST_DIR}/flags/cxx17.cmake")
 include("${CMAKE_CURRENT_LIST_DIR}/flags/cxx11-abi-disable.cmake") # effectively forced to 0 on RH7 and centos7, so disable to be consistent
-include("${CMAKE_CURRENT_LIST_DIR}/flags/skylake.cmake") # target explicit procesor
+include("${CMAKE_CURRENT_LIST_DIR}/flags/skylake.cmake") # target specific processor
 include("${CMAKE_CURRENT_LIST_DIR}/flags/fpic.cmake")

--- a/gcc-cxx17-skylake-pic-hide-ninja.cmake
+++ b/gcc-cxx17-skylake-pic-hide-ninja.cmake
@@ -1,0 +1,27 @@
+# Copyright (c) 2016-2017, Ruslan Baratov
+# Copyright (c) 2017, David Hirvonen
+# All rights reserved.
+
+# based on original gcc-7-cxx14-pic.cmake but assumes gcc itself is gcc v7
+
+if(DEFINED POLLY_GCC_CXX17_PIC_CMAKE_)
+  return()
+else()
+  set(POLLY_GCC_CXX17_PIC_CMAKE_ 1)
+endif()
+
+include("${CMAKE_CURRENT_LIST_DIR}/utilities/polly_init.cmake")
+
+polly_init(
+    "gcc / c++17 support / skylake / PIC"
+    "Ninja"
+)
+
+include("${CMAKE_CURRENT_LIST_DIR}/utilities/polly_common.cmake")
+
+include("${CMAKE_CURRENT_LIST_DIR}/compiler/gcc.cmake")
+include("${CMAKE_CURRENT_LIST_DIR}/flags/hidden.cmake")
+include("${CMAKE_CURRENT_LIST_DIR}/flags/cxx17.cmake")
+include("${CMAKE_CURRENT_LIST_DIR}/flags/cxx11-abi-disable.cmake") # effectively forced to 0 on RH7 and centos7, so disable to be consistent
+include("${CMAKE_CURRENT_LIST_DIR}/flags/skylake.cmake") # target generic procesor
+include("${CMAKE_CURRENT_LIST_DIR}/flags/fpic.cmake")

--- a/gcc-cxx17-skylake-pic-hide-ninja.cmake
+++ b/gcc-cxx17-skylake-pic-hide-ninja.cmake
@@ -23,5 +23,5 @@ include("${CMAKE_CURRENT_LIST_DIR}/compiler/gcc.cmake")
 include("${CMAKE_CURRENT_LIST_DIR}/flags/hidden.cmake")
 include("${CMAKE_CURRENT_LIST_DIR}/flags/cxx17.cmake")
 include("${CMAKE_CURRENT_LIST_DIR}/flags/cxx11-abi-disable.cmake") # effectively forced to 0 on RH7 and centos7, so disable to be consistent
-include("${CMAKE_CURRENT_LIST_DIR}/flags/skylake.cmake") # target generic procesor
+include("${CMAKE_CURRENT_LIST_DIR}/flags/skylake.cmake") # target explicit procesor
 include("${CMAKE_CURRENT_LIST_DIR}/flags/fpic.cmake")


### PR DESCRIPTION
Add gcc toolchain to select the x86-64 architecture to use. Don't just rely on default (native).