### PR TITLE
Add gcc C++17 toolchains without hide settings

### DIFF
--- a/gcc-cxx17-sandybridge-pic-ninja.cmake
+++ b/gcc-cxx17-sandybridge-pic-ninja.cmake
@@ -1,0 +1,26 @@
+# Copyright (c) 2016-2017, Ruslan Baratov
+# Copyright (c) 2017, David Hirvonen
+# All rights reserved.
+
+# based on original gcc-7-cxx14-pic.cmake but assumes gcc itself is gcc v7
+
+if(DEFINED POLLY_GCC_CXX17_SANDYBRIDGE_PIC_HIDE_NINJA_CMAKE_)
+  return()
+else()
+  set(POLLY_GCC_CXX17_SANDYBRIDGE_PIC_HIDE_NINJA_CMAKE_ 1)
+endif()
+
+include("${CMAKE_CURRENT_LIST_DIR}/utilities/polly_init.cmake")
+
+polly_init(
+	"gcc / c++17 support / Sandybridge / PIC"
+    "Ninja"
+)
+
+include("${CMAKE_CURRENT_LIST_DIR}/utilities/polly_common.cmake")
+
+include("${CMAKE_CURRENT_LIST_DIR}/compiler/gcc.cmake")
+include("${CMAKE_CURRENT_LIST_DIR}/flags/cxx17.cmake")
+include("${CMAKE_CURRENT_LIST_DIR}/flags/cxx11-abi-disable.cmake") # effectively forced to 0 on RH7 and centos7, so disable to be consistent
+include("${CMAKE_CURRENT_LIST_DIR}/flags/sandybridge.cmake") # target spoecific processor
+include("${CMAKE_CURRENT_LIST_DIR}/flags/fpic.cmake")

--- a/gcc-cxx17-skylake-pic-ninja.cmake
+++ b/gcc-cxx17-skylake-pic-ninja.cmake
@@ -1,0 +1,26 @@
+# Copyright (c) 2016-2017, Ruslan Baratov
+# Copyright (c) 2017, David Hirvonen
+# All rights reserved.
+
+# based on original gcc-7-cxx14-pic.cmake but assumes gcc itself is gcc v7
+
+if(DEFINED POLLY_GCC_CXX17_SKYLAKE_PIC_HIDE_NINJA_CMAKE_)
+  return()
+else()
+  set(POLLY_GCC_CXX17_SKYLAKE_PIC_HIDE_NINJA_CMAKE_ 1)
+endif()
+
+include("${CMAKE_CURRENT_LIST_DIR}/utilities/polly_init.cmake")
+
+polly_init(
+    "gcc / c++17 support / skylake / PIC"
+    "Ninja"
+)
+
+include("${CMAKE_CURRENT_LIST_DIR}/utilities/polly_common.cmake")
+
+include("${CMAKE_CURRENT_LIST_DIR}/compiler/gcc.cmake")
+include("${CMAKE_CURRENT_LIST_DIR}/flags/cxx17.cmake")
+include("${CMAKE_CURRENT_LIST_DIR}/flags/cxx11-abi-disable.cmake") # effectively forced to 0 on RH7 and centos7, so disable to be consistent
+include("${CMAKE_CURRENT_LIST_DIR}/flags/skylake.cmake") # target specific processor
+include("${CMAKE_CURRENT_LIST_DIR}/flags/fpic.cmake")


### PR DESCRIPTION
Intended for when we want shared libraries to export everything.