### PR TITLE
ENT-7720 Non-bitcode versions of our main iOS toolchains

### DIFF
--- a/ios-13-0-dep-9-3-arm64-cxx17-hide.cmake
+++ b/ios-13-0-dep-9-3-arm64-cxx17-hide.cmake
@@ -1,0 +1,43 @@
+# Copyright (c) 2017, Ruslan Baratov
+# All rights reserved.
+
+if(DEFINED POLLY_IOS_13_0_DEP_9_3_ARM64_CXX17_CMAKE_)
+  return()
+else()
+	set(POLLY_IOS_13_0_DEP_9_3_ARM64_CXX17_CMAKE_ 1)
+endif()
+
+include("${CMAKE_CURRENT_LIST_DIR}/utilities/polly_clear_environment_variables.cmake")
+
+include("${CMAKE_CURRENT_LIST_DIR}/utilities/polly_init.cmake")
+
+set(IOS_SDK_VERSION 13.0)
+set(IOS_DEPLOYMENT_SDK_VERSION 9.3)
+
+set(POLLY_XCODE_COMPILER "clang")
+polly_init(
+    "iOS ${IOS_SDK_VERSION} / Deployment ${IOS_DEPLOYMENT_SDK_VERSION} / Universal (arm64) / \
+${POLLY_XCODE_COMPILER} / \
+c++17 support"
+    "Xcode"
+)
+
+include("${CMAKE_CURRENT_LIST_DIR}/utilities/polly_common.cmake")
+
+include(polly_fatal_error)
+
+# Fix try_compile
+include(polly_ios_bundle_identifier)
+
+set(CMAKE_MACOSX_BUNDLE YES)
+set(CMAKE_XCODE_ATTRIBUTE_CODE_SIGN_IDENTITY "iPhone Developer")
+
+set(IPHONEOS_ARCHS arm64)
+set(IPHONESIMULATOR_ARCHS x86_64)
+
+include("${CMAKE_CURRENT_LIST_DIR}/compiler/xcode.cmake")
+include("${CMAKE_CURRENT_LIST_DIR}/flags/hidden.cmake")
+include("${CMAKE_CURRENT_LIST_DIR}/os/iphone.cmake")
+include("${CMAKE_CURRENT_LIST_DIR}/flags/cxx17.cmake")
+include("${CMAKE_CURRENT_LIST_DIR}/flags/fno-aligned-allocation.cmake") # aligned allocation needs iOS >= 11.0
+include("${CMAKE_CURRENT_LIST_DIR}/utilities/polly_ios_development_team.cmake")

--- a/ios-13-0-dep-9-3-arm64-hide.cmake
+++ b/ios-13-0-dep-9-3-arm64-hide.cmake
@@ -1,0 +1,43 @@
+# Copyright (c) 2017, Ruslan Baratov
+# All rights reserved.
+
+if(DEFINED POLLY_IOS_13_0_DEP_9_3_ARM64_CMAKE_)
+  return()
+else()
+  set(POLLY_IOS_13_0_DEP_9_3_ARM64_CMAKE_ 1)
+endif()
+
+include("${CMAKE_CURRENT_LIST_DIR}/utilities/polly_clear_environment_variables.cmake")
+
+include("${CMAKE_CURRENT_LIST_DIR}/utilities/polly_init.cmake")
+
+set(IOS_SDK_VERSION 13.0)
+set(IOS_DEPLOYMENT_SDK_VERSION 9.3)
+
+set(POLLY_XCODE_COMPILER "clang")
+polly_init(
+    "iOS ${IOS_SDK_VERSION} / Deployment ${IOS_DEPLOYMENT_SDK_VERSION} / Universal (arm64) / \
+${POLLY_XCODE_COMPILER} / \
+c++11 support"
+    "Xcode"
+)
+
+include("${CMAKE_CURRENT_LIST_DIR}/utilities/polly_common.cmake")
+
+include(polly_fatal_error)
+
+# Fix try_compile
+include(polly_ios_bundle_identifier)
+
+set(CMAKE_MACOSX_BUNDLE YES)
+set(CMAKE_XCODE_ATTRIBUTE_CODE_SIGN_IDENTITY "iPhone Developer")
+
+set(IPHONEOS_ARCHS arm64)
+set(IPHONESIMULATOR_ARCHS x86_64)
+
+include("${CMAKE_CURRENT_LIST_DIR}/compiler/xcode.cmake")
+include("${CMAKE_CURRENT_LIST_DIR}/flags/hidden.cmake")
+include("${CMAKE_CURRENT_LIST_DIR}/os/iphone.cmake")
+include("${CMAKE_CURRENT_LIST_DIR}/flags/cxx14.cmake")
+
+include("${CMAKE_CURRENT_LIST_DIR}/utilities/polly_ios_development_team.cmake")

--- a/ios-14-1-dep-9-3-arm64-cxx17-hide.cmake
+++ b/ios-14-1-dep-9-3-arm64-cxx17-hide.cmake
@@ -1,0 +1,45 @@
+# Copyright (c) 2017, Ruslan Baratov
+# All rights reserved.
+
+if(DEFINED POLLY_IOS_14_1_DEP_9_3_ARM64_CXX17_CMAKE_)
+  return()
+else()
+	set(POLLY_IOS_14_1_DEP_9_3_ARM64_CXX17_CMAKE_ 1)
+endif()
+
+include("${CMAKE_CURRENT_LIST_DIR}/utilities/polly_clear_environment_variables.cmake")
+
+include("${CMAKE_CURRENT_LIST_DIR}/utilities/polly_init.cmake")
+
+set(IOS_SDK_VERSION 14.1)
+set(IOS_DEPLOYMENT_SDK_VERSION 9.3)
+
+set(POLLY_XCODE_COMPILER "clang")
+polly_init(
+    "iOS ${IOS_SDK_VERSION} / Deployment ${IOS_DEPLOYMENT_SDK_VERSION} / Universal (arm64) / \
+${POLLY_XCODE_COMPILER} / \
+c++17 support"
+    "Xcode"
+)
+
+include("${CMAKE_CURRENT_LIST_DIR}/utilities/polly_common.cmake")
+
+include(polly_fatal_error)
+
+# Fix try_compile
+include(polly_ios_bundle_identifier)
+
+set(CMAKE_MACOSX_BUNDLE YES)
+set(CMAKE_XCODE_ATTRIBUTE_CODE_SIGN_IDENTITY "iPhone Developer")
+
+set(IPHONEOS_ARCHS arm64)
+set(IPHONESIMULATOR_ARCHS x86_64)
+
+set(CMAKE_GENERATOR_TOOLSET buildsystem=1) # force "old xcode build system"
+
+include("${CMAKE_CURRENT_LIST_DIR}/compiler/xcode.cmake")
+include("${CMAKE_CURRENT_LIST_DIR}/flags/hidden.cmake")
+include("${CMAKE_CURRENT_LIST_DIR}/os/iphone.cmake")
+include("${CMAKE_CURRENT_LIST_DIR}/flags/cxx17.cmake")
+include("${CMAKE_CURRENT_LIST_DIR}/flags/fno-aligned-allocation.cmake") # aligned allocation needs iOS >= 11.0
+include("${CMAKE_CURRENT_LIST_DIR}/utilities/polly_ios_development_team.cmake")


### PR DESCRIPTION
Seems Apple no longer want bitcode so switch back to not using it. Only add those toolchains it seems we use - others can follow if required.
