### PR TITLE
ENT-8552 Update to emscripten toolchains

### DIFF
--- a/compiler/emscripten.cmake
+++ b/compiler/emscripten.cmake
@@ -9,6 +9,9 @@ endif()
 
 include(polly_fatal_error)
 
+polly_add_cache_flag(CMAKE_C_ABI_COMPILED ON)
+polly_add_cache_flag(CMAKE_CXX_ABI_COMPILED ON)
+
 string(COMPARE EQUAL "$ENV{EMSDK}" "" _is_empty)
 if(_is_empty)
   polly_fatal_error(

--- a/compiler/emscripten.cmake
+++ b/compiler/emscripten.cmake
@@ -9,13 +9,13 @@ endif()
 
 include(polly_fatal_error)
 
-string(COMPARE EQUAL "$ENV{EMSCRIPTEN}" "" _is_empty)
+string(COMPARE EQUAL "$ENV{EMSDK}" "" _is_empty)
 if(_is_empty)
   polly_fatal_error(
-    "EMSCRIPTEN environment variable not set. Emscripten environment variables are in emsdk_env.sh"
+    "EMSDK environment variable not set. Emscripten environment variables are in emsdk_env.sh"
   )
 endif()
 
-include("$ENV{EMSCRIPTEN}/cmake/Modules/Platform/Emscripten.cmake")
+include("$ENV{EMSDK}/upstream/emscripten/cmake/Modules/Platform/Emscripten.cmake")
 list(APPEND CMAKE_FIND_ROOT_PATH "${CMAKE_CURRENT_LIST_DIR}/emscripten")
 

--- a/emscripten-threading-cxx17.cmake
+++ b/emscripten-threading-cxx17.cmake
@@ -1,0 +1,25 @@
+# Copyright (c) 2016, Alexandre Pretyman
+# All rights reserved.
+
+if(DEFINED POLLY_EMSCRIPTEN_CXX17_CMAKE)
+  return()
+else()
+  set(POLLY_EMSCRIPTEN_CXX17_CMAKE 1)
+endif()
+
+include("${CMAKE_CURRENT_LIST_DIR}/utilities/polly_init.cmake")
+
+polly_init(
+    "Emscripten Cross Compile / Threading / C++17"
+    "Unix Makefiles"
+)
+
+include("${CMAKE_CURRENT_LIST_DIR}/utilities/polly_common.cmake")
+include(polly_clear_environment_variables)
+include("${CMAKE_CURRENT_LIST_DIR}/flags/cxx17.cmake")
+include("${CMAKE_CURRENT_LIST_DIR}/compiler/emscripten.cmake")
+
+polly_add_cache_flag(CMAKE_EXE_LINKER_FLAGS "-pthread")
+polly_add_cache_flag(CMAKE_SHARED_LINKER_FLAGS "-pthread")
+polly_add_cache_flag(CMAKE_CXX_FLAGS "-pthread")
+polly_add_cache_flag(CMAKE_C_FLAGS "-pthread")

--- a/emscripten-threading-simd128-wasm-exceptions-cxx17.cmake
+++ b/emscripten-threading-simd128-wasm-exceptions-cxx17.cmake
@@ -1,0 +1,25 @@
+# Copyright (c) 2016, Alexandre Pretyman
+# All rights reserved.
+
+if(DEFINED POLLY_EMSCRIPTEN_CXX17_CMAKE)
+  return()
+else()
+  set(POLLY_EMSCRIPTEN_CXX17_CMAKE 1)
+endif()
+
+include("${CMAKE_CURRENT_LIST_DIR}/utilities/polly_init.cmake")
+
+polly_init(
+	"Emscripten Cross Compile / Threading / SIMD128 / WASM Exceptions / C++17"
+    "Unix Makefiles"
+)
+
+include("${CMAKE_CURRENT_LIST_DIR}/utilities/polly_common.cmake")
+include(polly_clear_environment_variables)
+include("${CMAKE_CURRENT_LIST_DIR}/flags/cxx17.cmake")
+include("${CMAKE_CURRENT_LIST_DIR}/compiler/emscripten.cmake")
+
+polly_add_cache_flag(CMAKE_EXE_LINKER_FLAGS "-pthread -msimd128 -fwasm-exceptions")
+polly_add_cache_flag(CMAKE_SHARED_LINKER_FLAGS "-pthread -msimd128 -fwasm-exceptions")
+polly_add_cache_flag(CMAKE_CXX_FLAGS "-pthread -msimd128 -fwasm-exceptions")
+polly_add_cache_flag(CMAKE_C_FLAGS "-pthread -msimd128 -fwasm-exceptions")


### PR DESCRIPTION
Update internal emscripten file to look for and work with $EMSDK not $EMSCRIPTEN, following what current emsdk now sets -
EMSCRIPTEN variable was renamed and subsequently removed.

Add further emscripten toolchains to enable extra features: variously threading, simd and proper exceptions.