### PR TITLE
ENT-9492 Emscripten toolchain setting bulk-memory not pthread

### DIFF
--- a/emscripten-bulkm-simd128-wasm-exceptions-cxx17.cmake
+++ b/emscripten-bulkm-simd128-wasm-exceptions-cxx17.cmake
@@ -1,0 +1,25 @@
+# Copyright (c) 2016, Alexandre Pretyman
+# All rights reserved.
+
+if(DEFINED POLLY_EMSCRIPTEN_CXX17_CMAKE)
+  return()
+else()
+  set(POLLY_EMSCRIPTEN_CXX17_CMAKE 1)
+endif()
+
+include("${CMAKE_CURRENT_LIST_DIR}/utilities/polly_init.cmake")
+
+polly_init(
+	"Emscripten Cross Compile / Bulk Memory / SIMD128 / WASM Exceptions / C++17"
+    "Unix Makefiles"
+)
+
+include("${CMAKE_CURRENT_LIST_DIR}/utilities/polly_common.cmake")
+include(polly_clear_environment_variables)
+include("${CMAKE_CURRENT_LIST_DIR}/flags/cxx17.cmake")
+include("${CMAKE_CURRENT_LIST_DIR}/compiler/emscripten.cmake")
+
+polly_add_cache_flag(CMAKE_EXE_LINKER_FLAGS "-mbulk-memory -msimd128 -fwasm-exceptions")
+polly_add_cache_flag(CMAKE_SHARED_LINKER_FLAGS "-mbulk-memory -msimd128 -fwasm-exceptions")
+polly_add_cache_flag(CMAKE_CXX_FLAGS "-mbulk-memory -msimd128 -fwasm-exceptions")
+polly_add_cache_flag(CMAKE_C_FLAGS "-mbulk-memory -msimd128 -fwasm-exceptions")


### PR DESCRIPTION
Add new emscripten toolchain that does not set -pthread but does set -mbulk-memory - seemingly allowing threaded code to compile but fail at run-time.
