### PR TITLE
ENT-10537 Support simulator-only and device-only iOS builds

### DIFF
--- a/flags/ios_nocodesign.cmake
+++ b/flags/ios_nocodesign.cmake
@@ -7,46 +7,61 @@ else()
   set(POLLY_FLAGS_IOS_NOCODESIGN_CMAKE_ 1)
 endif()
 
-# Verify XCODE_XCCONFIG_FILE
-set(
+if("${IOS_SDK_VERSION}" VERSION_GREATER_EQUAL "13.0")
+
+  set(CMAKE_XCODE_ATTRIBUTE_CODE_SIGN_IDENTITY "")
+  set(CMAKE_XCODE_ATTRIBUTE_CODE_SIGNING_REQUIRED NO)
+  set(CMAKE_XCODE_ATTRIBUTE_CODE_SIGN_ENTITLEMENTS "")
+  set(CMAKE_XCODE_ATTRIBUTE_CODE_SIGNING_ALLOWED NO)
+
+else()
+
+  # Verify XCODE_XCCONFIG_FILE
+  set(
     _polly_xcode_xcconfig_file_path
     "${CMAKE_CURRENT_LIST_DIR}/../scripts/NoCodeSign.xcconfig"
-)
+  )
 
-get_filename_component(
+  get_filename_component(
     _polly_xcode_xcconfig_file_path
     "${_polly_xcode_xcconfig_file_path}"
     ABSOLUTE
-)
+  )
 
-get_filename_component(
+  get_filename_component(
     _polly_xcode_xcconfig_file_path_env
     "$ENV{XCODE_XCCONFIG_FILE}"
-  ABSOLUTE
-)
+    ABSOLUTE
+  )
 
-if(NOT EXISTS "${_polly_xcode_xcconfig_file_path_env}")
-  polly_fatal_error(
-      "Path specified by XCODE_XCCONFIG_FILE environment variable not found"
-      "($ENV{XCODE_XCCONFIG_FILE})"
-      "Use this command to set: "
-      "    export XCODE_XCCONFIG_FILE=${_polly_xcode_xcconfig_file_path}"
-  )
-else()
-  string(
-      COMPARE
-      NOTEQUAL
-      "${_polly_xcode_xcconfig_file_path_env}"
-      "${_polly_xcode_xcconfig_file_path}"
-      _polly_wrong_xcconfig_path
-  )
-  if(_polly_wrong_xcconfig_path)
-    message(
-        WARNING
-        "Unexpected XCODE_XCCONFIG_FILE value: "
-        "    ${_polly_xcode_xcconfig_file_path_env}"
-        "expected: "
-        "    ${_polly_xcode_xcconfig_file_path}"
+  if(NOT EXISTS "${_polly_xcode_xcconfig_file_path_env}")
+    polly_fatal_error(
+        "Path specified by XCODE_XCCONFIG_FILE environment variable not found"
+        "($ENV{XCODE_XCCONFIG_FILE})"
+        "Use this command to set: "
+        "    export XCODE_XCCONFIG_FILE=${_polly_xcode_xcconfig_file_path}"
     )
+  else()
+    string(
+        COMPARE
+        NOTEQUAL
+        "${_polly_xcode_xcconfig_file_path_env}"
+        "${_polly_xcode_xcconfig_file_path}"
+        _polly_wrong_xcconfig_path
+    )
+    if(_polly_wrong_xcconfig_path)
+      message(
+          WARNING
+          "Unexpected XCODE_XCCONFIG_FILE value: "
+          "    ${_polly_xcode_xcconfig_file_path_env}"
+          "expected: "
+          "    ${_polly_xcode_xcconfig_file_path}"
+      )
+    endif()
   endif()
 endif()
+
+set(CMAKE_XCODE_ATTRIBUTE_CODE_SIGNING_ALLOWED NO CACHE STRING "" FORCE)
+set(CMAKE_XCODE_ATTRIBUTE_CODE_SIGN_ENTITLEMENTS "" CACHE STRING "" FORCE)
+set(CMAKE_XCODE_ATTRIBUTE_CODE_SIGNING_REQUIRED NO CACHE STRING "" FORCE)
+set(CMAKE_XCODE_ATTRIBUTE_CODE_SIGN_IDENTITY "" CACHE STRING "" FORCE)

--- a/ios-13-0-dep-9-3-arm64-cxx17-hide-nosim.cmake
+++ b/ios-13-0-dep-9-3-arm64-cxx17-hide-nosim.cmake
@@ -1,0 +1,43 @@
+# Copyright (c) 2017, Ruslan Baratov
+# All rights reserved.
+
+if(DEFINED POLLY_IOS_13_0_DEP_9_3_ARM64_CXX17_CMAKE_)
+  return()
+else()
+	set(POLLY_IOS_13_0_DEP_9_3_ARM64_CXX17_CMAKE_ 1)
+endif()
+
+include("${CMAKE_CURRENT_LIST_DIR}/utilities/polly_clear_environment_variables.cmake")
+
+include("${CMAKE_CURRENT_LIST_DIR}/utilities/polly_init.cmake")
+
+set(IOS_SDK_VERSION 13.0)
+set(IOS_DEPLOYMENT_SDK_VERSION 9.3)
+
+set(POLLY_XCODE_COMPILER "clang")
+polly_init(
+    "iOS ${IOS_SDK_VERSION} / Deployment ${IOS_DEPLOYMENT_SDK_VERSION} / device-only (arm64) / \
+${POLLY_XCODE_COMPILER} / \
+c++17 support"
+    "Xcode"
+)
+
+include("${CMAKE_CURRENT_LIST_DIR}/utilities/polly_common.cmake")
+
+include(polly_fatal_error)
+
+# Fix try_compile
+include(polly_ios_bundle_identifier)
+
+set(CMAKE_MACOSX_BUNDLE YES)
+set(CMAKE_XCODE_ATTRIBUTE_CODE_SIGN_IDENTITY "iPhone Developer")
+
+set(IPHONEOS_ARCHS arm64)
+set(IPHONESIMULATOR_ARCHS "")
+
+include("${CMAKE_CURRENT_LIST_DIR}/compiler/xcode.cmake")
+include("${CMAKE_CURRENT_LIST_DIR}/flags/hidden.cmake")
+include("${CMAKE_CURRENT_LIST_DIR}/os/iphone.cmake")
+include("${CMAKE_CURRENT_LIST_DIR}/flags/cxx17.cmake")
+include("${CMAKE_CURRENT_LIST_DIR}/flags/fno-aligned-allocation.cmake") # aligned allocation needs iOS >= 11.0
+include("${CMAKE_CURRENT_LIST_DIR}/utilities/polly_ios_development_team.cmake")

--- a/ios-nocodesign-arm64.cmake
+++ b/ios-nocodesign-arm64.cmake
@@ -1,67 +1,38 @@
-# Copyright (c) 2015, Ruslan Baratov
+# Copyright (c) 2016, Ruslan Baratov
 # All rights reserved.
 
-if(DEFINED POLLY_IOS_NOCODESIGN_ARM64_CMAKE)
+if(DEFINED POLLY_IOS_NOCODESIGN_ARM64_CMAKE_)
   return()
 else()
-  set(POLLY_IOS_NOCODESIGN_ARM64_CMAKE 1)
+  set(POLLY_IOS_NOCODESIGN_ARM64_CMAKE_ 1)
 endif()
 
-include("${CMAKE_CURRENT_LIST_DIR}/utilities/polly_clear_environment_variables.cmake")
+include("${CMAKE_CURRENT_LIST_DIR}/utilities/polly_module_path.cmake")
+include(polly_clear_environment_variables)
+include(polly_init)
 
-include("${CMAKE_CURRENT_LIST_DIR}/utilities/polly_init.cmake")
+include("${CMAKE_CURRENT_LIST_DIR}/os/iphone-default-sdk.cmake") # -> IOS_SDK_VERSION, IOS_DEPLOYMENT_SDK_VERSION
 
-set(IOS_SDK_VERSION 8.1)
 set(POLLY_XCODE_COMPILER "clang")
 polly_init(
-    "iOS ${IOS_SDK_VERSION} Universal (iphoneos + iphonesimulator) / \
+    "iOS ${IOS_SDK_VERSION} / Deployment ${IOS_DEPLOYMENT_SDK_VERSION} / arm64 / \
 ${POLLY_XCODE_COMPILER} / \
 No code sign / \
-c++11 support"
+c++14 support"
     "Xcode"
 )
 
-include("${CMAKE_CURRENT_LIST_DIR}/utilities/polly_common.cmake")
-
-include(polly_fatal_error)
+include(polly_common)
 
 # Fix try_compile
 include(polly_ios_bundle_identifier)
 set(CMAKE_MACOSX_BUNDLE YES)
 
-# Verify XCODE_XCCONFIG_FILE
-set(
-    _polly_xcode_xcconfig_file_path
-    "${CMAKE_CURRENT_LIST_DIR}/scripts/NoCodeSign.xcconfig"
-)
-if(NOT EXISTS "$ENV{XCODE_XCCONFIG_FILE}")
-  polly_fatal_error(
-      "Path specified by XCODE_XCCONFIG_FILE environment variable not found"
-      "($ENV{XCODE_XCCONFIG_FILE})"
-      "Use this command to set: "
-      "    export XCODE_XCCONFIG_FILE=${_polly_xcode_xcconfig_file_path}"
-  )
-else()
-  string(
-      COMPARE
-      NOTEQUAL
-      "$ENV{XCODE_XCCONFIG_FILE}"
-      "${_polly_xcode_xcconfig_file_path}"
-      _polly_wrong_xcconfig_path
-  )
-  if(_polly_wrong_xcconfig_path)
-    polly_fatal_error(
-        "Unexpected XCODE_XCCONFIG_FILE value: "
-        "    $ENV{XCODE_XCCONFIG_FILE}"
-        "expected: "
-        "    ${_polly_xcode_xcconfig_file_path}"
-    )
-  endif()
-endif()
+include("${CMAKE_CURRENT_LIST_DIR}/flags/ios_nocodesign.cmake")
 
 set(IPHONEOS_ARCHS arm64)
 set(IPHONESIMULATOR_ARCHS "")
 
 include("${CMAKE_CURRENT_LIST_DIR}/compiler/xcode.cmake")
 include("${CMAKE_CURRENT_LIST_DIR}/os/iphone.cmake")
-include("${CMAKE_CURRENT_LIST_DIR}/flags/cxx11.cmake")
+include("${CMAKE_CURRENT_LIST_DIR}/flags/cxx14.cmake")

--- a/ios-nocodesign-simarm64-cxx17.cmake
+++ b/ios-nocodesign-simarm64-cxx17.cmake
@@ -1,0 +1,38 @@
+# Copyright (c) 2016, Ruslan Baratov
+# All rights reserved.
+
+if(DEFINED POLLY_IOS_NOCODESIGN_SIMARM64_CMAKE_)
+  return()
+else()
+  set(POLLY_IOS_NOCODESIGN_SIMARM64_CMAKE_ 1)
+endif()
+
+include("${CMAKE_CURRENT_LIST_DIR}/utilities/polly_module_path.cmake")
+include(polly_clear_environment_variables)
+include(polly_init)
+
+include("${CMAKE_CURRENT_LIST_DIR}/os/iphone-default-sdk.cmake") # -> IOS_SDK_VERSION, IOS_DEPLOYMENT_SDK_VERSION
+
+set(POLLY_XCODE_COMPILER "clang")
+polly_init(
+    "iOS ${IOS_SDK_VERSION} / Deployment ${IOS_DEPLOYMENT_SDK_VERSION} / simulator arm64 / \
+${POLLY_XCODE_COMPILER} / \
+No code sign / \
+c++17 support"
+    "Xcode"
+)
+
+include(polly_common)
+
+# Fix try_compile
+include(polly_ios_bundle_identifier)
+set(CMAKE_MACOSX_BUNDLE YES)
+
+include("${CMAKE_CURRENT_LIST_DIR}/flags/ios_nocodesign.cmake")
+
+set(IPHONEOS_ARCHS "")
+set(IPHONESIMULATOR_ARCHS arm64)
+
+include("${CMAKE_CURRENT_LIST_DIR}/compiler/xcode.cmake")
+include("${CMAKE_CURRENT_LIST_DIR}/os/iphone.cmake")
+include("${CMAKE_CURRENT_LIST_DIR}/flags/cxx17.cmake")

--- a/ios-nocodesign-simarm64-cxx17.cmake
+++ b/ios-nocodesign-simarm64-cxx17.cmake
@@ -36,3 +36,5 @@ set(IPHONESIMULATOR_ARCHS arm64)
 include("${CMAKE_CURRENT_LIST_DIR}/compiler/xcode.cmake")
 include("${CMAKE_CURRENT_LIST_DIR}/os/iphone.cmake")
 include("${CMAKE_CURRENT_LIST_DIR}/flags/cxx17.cmake")
+
+set_property(GLOBAL PROPERTY XCODE_EMIT_EFFECTIVE_PLATFORM_NAME OFF)

--- a/ios-nocodesign-simx86_64-cxx17.cmake
+++ b/ios-nocodesign-simx86_64-cxx17.cmake
@@ -36,3 +36,6 @@ set(IPHONESIMULATOR_ARCHS x86_64)
 include("${CMAKE_CURRENT_LIST_DIR}/compiler/xcode.cmake")
 include("${CMAKE_CURRENT_LIST_DIR}/os/iphone.cmake")
 include("${CMAKE_CURRENT_LIST_DIR}/flags/cxx17.cmake")
+if("${IOS_SDK_VERSION}" VERSION_LESS "11.0")
+  include("${CMAKE_CURRENT_LIST_DIR}/flags/fno-aligned-allocation.cmake") # aligned allocation needs iOS >= 11.0
+endif()

--- a/ios-nocodesign-simx86_64-cxx17.cmake
+++ b/ios-nocodesign-simx86_64-cxx17.cmake
@@ -36,6 +36,6 @@ set(IPHONESIMULATOR_ARCHS x86_64)
 include("${CMAKE_CURRENT_LIST_DIR}/compiler/xcode.cmake")
 include("${CMAKE_CURRENT_LIST_DIR}/os/iphone.cmake")
 include("${CMAKE_CURRENT_LIST_DIR}/flags/cxx17.cmake")
-if("${IOS_SDK_VERSION}" VERSION_LESS "11.0")
+if("${IOS_DEPLOYMENT_SDK_VERSION}" VERSION_LESS "11.0")
   include("${CMAKE_CURRENT_LIST_DIR}/flags/fno-aligned-allocation.cmake") # aligned allocation needs iOS >= 11.0
 endif()

--- a/ios-nocodesign-simx86_64-cxx17.cmake
+++ b/ios-nocodesign-simx86_64-cxx17.cmake
@@ -39,3 +39,5 @@ include("${CMAKE_CURRENT_LIST_DIR}/flags/cxx17.cmake")
 if("${IOS_DEPLOYMENT_SDK_VERSION}" VERSION_LESS "11.0")
   include("${CMAKE_CURRENT_LIST_DIR}/flags/fno-aligned-allocation.cmake") # aligned allocation needs iOS >= 11.0
 endif()
+
+set_property(GLOBAL PROPERTY XCODE_EMIT_EFFECTIVE_PLATFORM_NAME OFF)

--- a/ios-nocodesign-simx86_64-cxx17.cmake
+++ b/ios-nocodesign-simx86_64-cxx17.cmake
@@ -1,0 +1,38 @@
+# Copyright (c) 2016, Ruslan Baratov
+# All rights reserved.
+
+if(DEFINED POLLY_IOS_NOCODESIGN_SIMX86_64_CMAKE_)
+  return()
+else()
+  set(POLLY_IOS_NOCODESIGN_SIMX86_64_CMAKE_ 1)
+endif()
+
+include("${CMAKE_CURRENT_LIST_DIR}/utilities/polly_module_path.cmake")
+include(polly_clear_environment_variables)
+include(polly_init)
+
+include("${CMAKE_CURRENT_LIST_DIR}/os/iphone-default-sdk.cmake") # -> IOS_SDK_VERSION, IOS_DEPLOYMENT_SDK_VERSION
+
+set(POLLY_XCODE_COMPILER "clang")
+polly_init(
+    "iOS ${IOS_SDK_VERSION} / Deployment ${IOS_DEPLOYMENT_SDK_VERSION} / simulator x86_64 / \
+${POLLY_XCODE_COMPILER} / \
+No code sign / \
+c++17 support"
+    "Xcode"
+)
+
+include(polly_common)
+
+# Fix try_compile
+include(polly_ios_bundle_identifier)
+set(CMAKE_MACOSX_BUNDLE YES)
+
+include("${CMAKE_CURRENT_LIST_DIR}/flags/ios_nocodesign.cmake")
+
+set(IPHONEOS_ARCHS "")
+set(IPHONESIMULATOR_ARCHS x86_64)
+
+include("${CMAKE_CURRENT_LIST_DIR}/compiler/xcode.cmake")
+include("${CMAKE_CURRENT_LIST_DIR}/os/iphone.cmake")
+include("${CMAKE_CURRENT_LIST_DIR}/flags/cxx17.cmake")

--- a/ios-nocodesign.cmake
+++ b/ios-nocodesign.cmake
@@ -7,56 +7,27 @@ else()
   set(POLLY_IOS_NOCODESIGN_CMAKE_ 1)
 endif()
 
-
 include("${CMAKE_CURRENT_LIST_DIR}/utilities/polly_module_path.cmake")
 include(polly_clear_environment_variables)
 include(polly_init)
-include("${CMAKE_CURRENT_LIST_DIR}/os/iphone-default-sdk.cmake") # -> IOS_SDK_VERSION
+
+include("${CMAKE_CURRENT_LIST_DIR}/os/iphone-default-sdk.cmake") # -> IOS_SDK_VERSION, IOS_DEPLOYMENT_SDK_VERSION
 
 set(POLLY_XCODE_COMPILER "clang")
 polly_init(
-  "iOS ${IOS_SDK_VERSION} Universal (iphoneos + iphonesimulator) / \
+    "iOS ${IOS_SDK_VERSION} / Deployment ${IOS_DEPLOYMENT_SDK_VERSION} / Universal (iphoneos + iphonesimulator) / \
 ${POLLY_XCODE_COMPILER} / \
 c++14 support"
-  "Xcode"
+    "Xcode"
 )
 
 include(polly_common)
-include(polly_fatal_error)
 
 # Fix try_compile
 include(polly_ios_bundle_identifier)
 set(CMAKE_MACOSX_BUNDLE YES)
 
-# Verify XCODE_XCCONFIG_FILE
-set(
-  _polly_xcode_xcconfig_file_path
-    "${CMAKE_CURRENT_LIST_DIR}/scripts/NoCodeSign.xcconfig"
-)
-if(NOT EXISTS "$ENV{XCODE_XCCONFIG_FILE}")
-  polly_fatal_error(
-    "Path specified by XCODE_XCCONFIG_FILE environment variable not found"
-    "($ENV{XCODE_XCCONFIG_FILE})"
-    "Use this command to set: "
-    "    export XCODE_XCCONFIG_FILE=${_polly_xcode_xcconfig_file_path}"
-  )
-else()
-  string(
-    COMPARE
-    NOTEQUAL
-    "$ENV{XCODE_XCCONFIG_FILE}"
-    "${_polly_xcode_xcconfig_file_path}"
-    _polly_wrong_xcconfig_path
-  )
-  if(_polly_wrong_xcconfig_path)
-    polly_fatal_error(
-        "Unexpected XCODE_XCCONFIG_FILE value: "
-        "    $ENV{XCODE_XCCONFIG_FILE}"
-        "expected: "
-        "    ${_polly_xcode_xcconfig_file_path}"
-    )
-  endif()
-endif()
+include("${CMAKE_CURRENT_LIST_DIR}/flags/ios_nocodesign.cmake")
 
 # 32 bits support was dropped from iPhoneSdk11.0
 if(IOS_SDK_VERSION VERSION_LESS "11.0")

--- a/ios.cmake
+++ b/ios.cmake
@@ -10,20 +10,20 @@ endif()
 include("${CMAKE_CURRENT_LIST_DIR}/utilities/polly_module_path.cmake")
 include(polly_clear_environment_variables)
 include(polly_init)
-include("${CMAKE_CURRENT_LIST_DIR}/os/iphone-default-sdk.cmake") # -> IOS_SDK_VERSION
+
+include("${CMAKE_CURRENT_LIST_DIR}/os/iphone-default-sdk.cmake") # -> IOS_SDK_VERSION, IOS_DEPLOYMENT_SDK_VERSION
 
 set(POLLY_XCODE_COMPILER "clang")
 polly_init(
-  "iOS ${IOS_SDK_VERSION} Universal (iphoneos + iphonesimulator) / \
+    "iOS ${IOS_SDK_VERSION} / Deployment ${IOS_DEPLOYMENT_SDK_VERSION} / Universal (iphoneos + iphonesimulator) / \
 ${POLLY_XCODE_COMPILER} / \
 c++14 support"
-  "Xcode"
+    "Xcode"
 )
 
 include(polly_common)
-include(polly_fatal_error)
 
-# # Fix try_compile
+# Fix try_compile
 include(polly_ios_bundle_identifier)
 set(CMAKE_MACOSX_BUNDLE YES)
 

--- a/os/iphone-default-sdk.cmake
+++ b/os/iphone-default-sdk.cmake
@@ -1,5 +1,6 @@
 # This script sets the following variables :
 # IOS_SDK_VERSION : will contain the version number of the default iOS SDK (example : 11.0)
+# IOS_DEPLOYMENT_SDK_VERSION: minimum suggestd Deployment SDK version
 # IPHONEOS_SDK_ROOT : full path to the SDK
 # IPHONEOS_ROOT
 # XCODE_DEVELOPER_ROOT
@@ -71,3 +72,25 @@ if(NOT "${_POLLY_PROCESS_RESULT}" EQUAL "0")
     ")
 endif()
 polly_status_debug("IOS_SDK_VERSION=${IOS_SDK_VERSION}")
+
+if(NOT IOS_DEPLOYMENT_SDK_VERSION)
+  # Get minimum suggested Deployment SDK version
+  execute_process(
+    COMMAND
+    "/usr/libexec/PlistBuddy"
+    -c "print 'DefaultProperties':DEPLOYMENT_TARGET_SUGGESTED_VALUES:0"
+    ${IPHONEOS_SDK_ROOT}/SDKSettings.plist
+    RESULT_VARIABLE _POLLY_PROCESS_RESULT2
+    OUTPUT_VARIABLE IOS_DEPLOYMENT_SDK_VERSION
+    OUTPUT_STRIP_TRAILING_WHITESPACE
+    ERROR_STRIP_TRAILING_WHITESPACE
+  )
+  if(NOT "${_POLLY_PROCESS_RESULT2}" EQUAL "0")
+    polly_fatal_error("Could not read the minimum suggested Deployment iPhoneSDK version ().
+      The command
+      /usr/libexec/PlistBuddy -c \"print 'DefaultProperties':DEPLOYMENT_TARGET_SUGGESTED_VALUES:0\" ${IPHONEOS_SDK_ROOT}/SDKSettings.plist
+      failed with the following status : ${_POLLY_PROCESS_RESULT2}
+      ")
+  endif()
+endif()
+polly_status_debug("IOS_DEPLOYMENT_SDK_VERSION=${IOS_DEPLOYMENT_SDK_VERSION}")

--- a/os/iphone.cmake
+++ b/os/iphone.cmake
@@ -26,6 +26,12 @@ if(CMAKE_VERSION VERSION_LESS "3.5")
   )
 endif()
 
+if("${IOS_SDK_VERSION}" VERSION_GREATER_EQUAL "13.0" AND "${CMAKE_VERSION}" VERSION_LESS "3.14")
+  polly_fatal_error(
+      "CMake minimum required version for iOS SDK Version ${IOS_SDK_VERSION} is 3.14 (current ver: ${CMAKE_VERSION})"
+  )
+endif()
+
 string(COMPARE EQUAL "$ENV{DEVELOPER_DIR}" "" _is_empty)
 if(NOT _is_empty)
   polly_status_debug("Developer root (env): $ENV{DEVELOPER_DIR}")
@@ -148,11 +154,16 @@ set(CMAKE_XCODE_ATTRIBUTE_VALID_ARCHS[sdk=iphonesimulator*] "${archs}")
 # Introduced in iOS 9.0
 set(CMAKE_XCODE_ATTRIBUTE_ENABLE_BITCODE NO)
 
-# This will set CMAKE_CROSSCOMPILING to TRUE.
-# CMAKE_CROSSCOMPILING needed for try_run:
-# * https://cmake.org/cmake/help/latest/command/try_run.html#behavior-when-cross-compiling
-# (used in CURL)
-set(CMAKE_SYSTEM_NAME "Darwin")
+if("${CMAKE_VERSION}" VERSION_GREATER_EQUAL "3.14")
+  # set proper system name see https://cmake.org/cmake/help/v3.14/manual/cmake-toolchains.7.html#cross-compiling-for-ios-tvos-or-watchos
+  set(CMAKE_SYSTEM_NAME "iOS")
+else()
+  # This will set CMAKE_CROSSCOMPILING to TRUE.
+  # CMAKE_CROSSCOMPILING needed for try_run:
+  # * https://cmake.org/cmake/help/latest/command/try_run.html#behavior-when-cross-compiling
+  # (used in CURL)
+  set(CMAKE_SYSTEM_NAME "Darwin")
+endif()
 
 # Set CMAKE_SYSTEM_PROCESSOR for one-arch toolchain
 # (needed for OpenCV 3.3)
@@ -162,4 +173,10 @@ if(_all_archs_len EQUAL 1)
   set(CMAKE_SYSTEM_PROCESSOR ${_all_archs})
 else()
   set(CMAKE_SYSTEM_PROCESSOR "")
+endif()
+
+# fix try_compile "Detecting C compiler ABI info - failed" error
+# https://gitlab.kitware.com/cmake/cmake/-/issues/19720
+if("${IOS_SDK_VERSION}" VERSION_GREATER_EQUAL "13.0")
+  set(CMAKE_TRY_COMPILE_CONFIGURATION Release)
 endif()

--- a/os/iphone.cmake
+++ b/os/iphone.cmake
@@ -7,8 +7,16 @@ else()
   set(POLLY_OS_IPHONE_CMAKE 1)
 endif()
 
-set(CMAKE_OSX_SYSROOT "iphoneos" CACHE STRING "System root for iOS" FORCE)
-set(CMAKE_XCODE_EFFECTIVE_PLATFORMS "-iphoneos;-iphonesimulator")
+if(IPHONEOS_ARCHS AND IPHONESIMULATOR_ARCHS)
+  set(CMAKE_OSX_SYSROOT "iphoneos" CACHE STRING "System root for iOS" FORCE)
+  set(CMAKE_XCODE_EFFECTIVE_PLATFORMS "-iphoneos;-iphonesimulator")
+elseif(IPHONEOS_ARCHS)
+  set(CMAKE_OSX_SYSROOT "iphoneos" CACHE STRING "System root for iOS" FORCE)
+  set(CMAKE_XCODE_EFFECTIVE_PLATFORMS "-iphoneos")
+else()
+  set(CMAKE_OSX_SYSROOT "iphonesimulator" CACHE STRING "System root for iOS Simulator" FORCE)
+  set(CMAKE_XCODE_EFFECTIVE_PLATFORMS "-iphonesimulator")
+endif()
 
 # find 'iphoneos' and 'iphonesimulator' roots and version
 find_program(XCODE_SELECT_EXECUTABLE xcode-select)
@@ -136,20 +144,19 @@ set(IOS YES)
 # -- end
 
 # Set iPhoneOS architectures
-set(archs "")
-foreach(arch ${IPHONEOS_ARCHS})
-  set(archs "${archs} ${arch}")
-endforeach()
-set(CMAKE_XCODE_ATTRIBUTE_ARCHS[sdk=iphoneos*] "${archs}")
-set(CMAKE_XCODE_ATTRIBUTE_VALID_ARCHS[sdk=iphoneos*] "${archs}")
+string(REPLACE ";" " " archs "${IPHONEOS_ARCHS}")
+if(archs)
+  set(valid_archs ${archs})
+  set(CMAKE_XCODE_ATTRIBUTE_ARCHS[sdk=iphoneos*] "${archs}")
+  set(CMAKE_XCODE_ATTRIBUTE_VALID_ARCHS[sdk=iphoneos*] "${archs}")
+endif()
 
 # Set iPhoneSimulator architectures
-set(archs "")
-foreach(arch ${IPHONESIMULATOR_ARCHS})
-  set(archs "${archs} ${arch}")
-endforeach()
-set(CMAKE_XCODE_ATTRIBUTE_ARCHS[sdk=iphonesimulator*] "${archs}")
-set(CMAKE_XCODE_ATTRIBUTE_VALID_ARCHS[sdk=iphonesimulator*] "${archs}")
+string(REPLACE ";" " " archs "${IPHONESIMULATOR_ARCHS}")
+if(archs)
+  set(CMAKE_XCODE_ATTRIBUTE_ARCHS[sdk=iphonesimulator*] "${archs}")
+  set(CMAKE_XCODE_ATTRIBUTE_VALID_ARCHS[sdk=iphonesimulator*] "${archs}")
+endif()
 
 # Introduced in iOS 9.0
 set(CMAKE_XCODE_ATTRIBUTE_ENABLE_BITCODE NO)


### PR DESCRIPTION
Add new toolchains to build for iOS using separate simulator and device builds, now that using CMAKE_IOS_INSTALL_COMBINED is deprecated.

Cherry-pick changes iOS that allow the iOS default deployment target to be discovered - use for new simulator builds rather than hardwire. Local updates to os/iphone.cmake, in particular, to not set device architectures and set target correctly when there are no device architectures provided - seems currently broken upstream on cpp-pm/polly.