### PR TITLE
ENT-12548 Add toolchain for VS2022

### DIFF
--- a/vs-17-2022-win64-cxx17.cmake
+++ b/vs-17-2022-win64-cxx17.cmake
@@ -1,0 +1,20 @@
+# Copyright (c) 2015-2022, Ruslan Baratov, Rahul Sheth
+# All rights reserved.
+
+if(DEFINED POLLY_VS_17_2022_WIN64_CXX17_CMAKE_)
+  return()
+else()
+  set(POLLY_VS_17_2022_WIN64_CXX17_CMAKE_ 1)
+endif()
+
+include("${CMAKE_CURRENT_LIST_DIR}/utilities/polly_init.cmake")
+
+polly_init(
+    "Visual Studio 17 2022 Win64 / C++17"
+    "Visual Studio 17 2022"
+)
+
+include("${CMAKE_CURRENT_LIST_DIR}/utilities/polly_common.cmake")
+include("${CMAKE_CURRENT_LIST_DIR}/flags/vs-cxx17.cmake")
+
+include("${CMAKE_CURRENT_LIST_DIR}/flags/vs-platform-x64.cmake")


### PR DESCRIPTION
Cherry-pick the version from upstream cpp-pm/polly - this is effectively identical to that of VS2017.